### PR TITLE
Endpoint admin para buscar igreja por id sem filtrar ativo

### DIFF
--- a/BuscaMissa/Controllers/v2/IgrejaController.cs
+++ b/BuscaMissa/Controllers/v2/IgrejaController.cs
@@ -160,6 +160,25 @@ namespace BuscaMissa.Controllers.v2
             _ => null
         };
 
+        // Endpoint admin: busca completa por Id, sem filtrar por Ativo (uso no painel administrativo)
+        [HttpGet("admin/{id:int}")]
+        [Authorize(Roles = "Admin")]
+        public async Task<ActionResult> BuscarPorIdAdminAsync(int id)
+        {
+            try
+            {
+                var igreja = await igrejaServiceV2.BuscarPorIdAdminAsync(id);
+                if (igreja is null) return NotFound();
+
+                return Ok(new ApiResponse<dynamic>(new { igreja }));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                return StatusCode(StatusCodes.Status500InternalServerError, new ApiResponse<dynamic>(ex.Message));
+            }
+        }
+
         // Item 2: endpoint público para busca por NomeUnico (sem autenticação, para SEO)
         // Item 5: retorna metadados de SEO junto com os dados da igreja
         [HttpGet("{nomeUnico}")]

--- a/BuscaMissa/DTOs/v1/IgrejaDto/FiltroIgrejaAdminRequest.cs
+++ b/BuscaMissa/DTOs/v1/IgrejaDto/FiltroIgrejaAdminRequest.cs
@@ -7,11 +7,15 @@ namespace BuscaMissa.DTOs.IgrejaDto
 {
     public class FiltroIgrejaAdminRequest : IValidatableObject
     {
+        public int? Id { get; set; }
         public string? Uf { get; set; } = default!;
         public string? Localidade { get; set; }
         public string? Bairro { get; set; }
+        public string? Cep { get; set; }
         [NoProfanity]
         public string? Nome { get; set; }
+        [NoProfanity]
+        public string? Paroco { get; set; }
         public bool Ativo { get; set; } = true;
         public DiaDaSemanaEnum? DiaDaSemana { get; set; }
         public string? Horario { get; set; }
@@ -19,6 +23,7 @@ namespace BuscaMissa.DTOs.IgrejaDto
         public PaginacaoRequest Paginacao { get; set; } = default!;
         public bool Solicitacao { get; set; } = false;
         public bool Denuncia { get; set; } = false;
+        public bool SemCoordenadas { get; set; } = false;
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {

--- a/BuscaMissa/Services/v1/IgrejaService.cs
+++ b/BuscaMissa/Services/v1/IgrejaService.cs
@@ -578,6 +578,9 @@ namespace BuscaMissa.Services.v1
                         x.Ativo == filtro.Ativo)
                     .AsQueryable();
 
+                if (filtro.Id is not null)
+                    query = query.Where(x => x.Id == filtro.Id);
+
                 if (!string.IsNullOrEmpty(filtro.Uf))
                     query = query.Where(x => x.Endereco.Uf == filtro.Uf.ToUpper());
 
@@ -587,8 +590,14 @@ namespace BuscaMissa.Services.v1
                 if (!string.IsNullOrEmpty(filtro.Bairro))
                     query = query.Where(x => x.Endereco.Bairro == filtro.Bairro);
 
+                if (!string.IsNullOrEmpty(filtro.Cep))
+                    query = query.Where(x => x.Endereco.Cep == CepHelper.FormatarCep(filtro.Cep));
+
                 if (!string.IsNullOrEmpty(filtro.Nome))
                     query = query.Where(x => x.Nome.ToUpper().Contains(filtro.Nome.ToUpper()));
+
+                if (!string.IsNullOrEmpty(filtro.Paroco))
+                    query = query.Where(x => x.Paroco != null && x.Paroco.ToUpper().Contains(filtro.Paroco.ToUpper()));
 
                 if (filtro.DiaDaSemana is not null)
                     query = query.Where(x => x.Missas.Any(y => y.DiaSemana == filtro.DiaDaSemana));
@@ -598,6 +607,9 @@ namespace BuscaMissa.Services.v1
 
                 if (filtro.Denuncia)
                     query = query.Where(x => x.Denuncia != null && string.IsNullOrEmpty(x.Denuncia.AcaoRealizada));
+
+                if (filtro.SemCoordenadas)
+                    query = query.Where(x => x.Endereco.Latitude == null);
 
                 var aux = query.Select(x => new IgrejaResponse()
                 {

--- a/BuscaMissa/Services/v2/IgrejaService.cs
+++ b/BuscaMissa/Services/v2/IgrejaService.cs
@@ -186,6 +186,34 @@ public class IgrejaService(
         }
     }
 
+    public async Task<IgrejaResponse?> BuscarPorIdAdminAsync(int id)
+    {
+        try
+        {
+            var model = await context.Igrejas
+                .Include(x => x.Endereco)
+                .Include(x => x.Missas)
+                .Include(x => x.Usuario)
+                .Include(x => x.Contato)
+                .Include(x => x.RedesSociais)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x => x.Id == id);
+
+            if (model == null) return null;
+
+            var response = (IgrejaResponse)model;
+            if (!string.IsNullOrEmpty(model.ImagemUrl))
+                response.ImagemUrl = imagemService.ObterUrlAzureBlob($"igreja/{model.ImagemUrl}");
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An error occurred while searching Igreja by id (admin) {Id}", id);
+            throw;
+        }
+    }
+
     public async Task<IgrejaResponse?> BuscarPorNomeUnicoAsync(string nomeUnico)
     {
         try


### PR DESCRIPTION
## Summary
- Adiciona `GET /api/v2/Igreja/admin/{id}` autenticado (Admin) que retorna a igreja completa (endereço, missas, contato, redes sociais) independente do status `Ativo`
- Resolve o problema do modal de busca por CEP no admin, que usava o endpoint público `{nomeUnico}` (filtrado por `Ativo`) e falhava para igrejas inativas

## Test plan
- [ ] Testar `GET /api/v2/Igreja/admin/{id}` com uma igreja inativa e confirmar retorno 200 com dados completos
- [ ] Confirmar que o endpoint exige role Admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)