### PR TITLE
feat: assistente de divulgação – canais de contato em EmailEventoIgreja

### DIFF
--- a/BuscaMissa/Controllers/v1/AdminController.cs
+++ b/BuscaMissa/Controllers/v1/AdminController.cs
@@ -594,6 +594,32 @@ namespace BuscaMissa.Controllers.v1
             }
         }
 
+        [HttpPost]
+        [Route("email-evento/registrar-contato")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> RegistrarContato([FromBody] RegistrarContatoRequest request)
+        {
+            try
+            {
+                if (!ModelState.IsValid) return BadRequest(ModelState);
+
+                var igreja = await igrejaService.BuscarPorIdAsync(request.IgrejaId);
+                if (igreja is null)
+                    return NotFound(new ApiResponse<dynamic>(new { mensagemAplicacao = "Igreja não encontrada." }));
+
+                var model = await emailEventoIgrejaService.RegistrarContatoAsync(request);
+                var response = (EmailEventoIgrejaResponse)model;
+
+                return Ok(new ApiResponse<dynamic>(new { response }));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                var response = new ApiResponse<dynamic>(ex.Message);
+                return StatusCode(StatusCodes.Status500InternalServerError, response);
+            }
+        }
+
         [HttpPut]
         [Route("email-evento/atualizar/{id}")]
         [Authorize(Roles = "Admin")]

--- a/BuscaMissa/DTOs/v1/EmailEventoIgrejaDto/CriarEmailEventoIgrejaRequest.cs
+++ b/BuscaMissa/DTOs/v1/EmailEventoIgrejaDto/CriarEmailEventoIgrejaRequest.cs
@@ -11,10 +11,7 @@ public class CriarEmailEventoIgrejaRequest
 
     [Required] [MaxLength(200)] public string Assunto { get; set; } = null!;
 
-    [Required]
-    [EmailAddress]
-    [MaxLength(255)]
-    public string EmailDestino { get; set; } = null!;
+    [Required] [EmailAddress] [MaxLength(255)] public string EmailDestino { get; set; } = null!;
 
     [MaxLength(120)] public string? NomeDestino { get; set; }
 

--- a/BuscaMissa/DTOs/v1/EmailEventoIgrejaDto/EmailEventoIgrejaResponse.cs
+++ b/BuscaMissa/DTOs/v1/EmailEventoIgrejaDto/EmailEventoIgrejaResponse.cs
@@ -11,6 +11,12 @@ public class EmailEventoIgrejaResponse
 
     public string? IgrejaNome { get; set; }
 
+    public string? IgrejaUf { get; set; }
+
+    public string? IgrejaCidadeSlug { get; set; }
+
+    public string? IgrejaSlug { get; set; }
+
     public TipoEmailEventoIgrejaEnum Tipo { get; set; }
 
     public string TipoDescricao => Tipo.ToString();
@@ -35,6 +41,10 @@ public class EmailEventoIgrejaResponse
 
     public string? Observacao { get; set; }
 
+    public CanalContatoEnum Canal { get; set; }
+
+    public string? DestinoContato { get; set; }
+
     public static explicit operator EmailEventoIgrejaResponse(EmailEventoIgreja model)
     {
         return new EmailEventoIgrejaResponse
@@ -42,6 +52,9 @@ public class EmailEventoIgrejaResponse
             Id = model.Id,
             IgrejaId = model.IgrejaId,
             IgrejaNome = model.Igreja?.Nome,
+            IgrejaUf = model.Igreja?.Endereco?.Uf?.ToLower(),
+            IgrejaCidadeSlug = model.Igreja?.Endereco?.CidadeSlug,
+            IgrejaSlug = model.Igreja?.Slug,
             Tipo = model.Tipo,
             Assunto = model.Assunto,
             EmailDestino = model.EmailDestino,
@@ -52,7 +65,9 @@ public class EmailEventoIgrejaResponse
             DataEnvio = model.DataEnvio,
             DataCriacao = model.DataCriacao,
             DataAlteracao = model.DataAlteracao,
-            Observacao = model.Observacao
+            Observacao = model.Observacao,
+            Canal = model.Canal,
+            DestinoContato = model.DestinoContato
         };
     }
 }

--- a/BuscaMissa/DTOs/v1/EmailEventoIgrejaDto/FiltroEmailEventoIgrejaRequest.cs
+++ b/BuscaMissa/DTOs/v1/EmailEventoIgrejaDto/FiltroEmailEventoIgrejaRequest.cs
@@ -7,13 +7,23 @@ public class FiltroEmailEventoIgrejaRequest : PaginacaoRequest
 {
     public int? IgrejaId { get; set; }
 
+    public string? IgrejaNome { get; set; }
+
+    public string? Cidade { get; set; }
+
     public TipoEmailEventoIgrejaEnum? Tipo { get; set; }
+
+    public CanalContatoEnum? Canal { get; set; }
 
     public string? EmailDestino { get; set; }
 
     public bool? Ativo { get; set; }
 
     public bool? Enviado { get; set; }
+
+    public DateTime? DataEnvioInicio { get; set; }
+
+    public DateTime? DataEnvioFim { get; set; }
 
     public DateTime? DataCriacaoInicio { get; set; }
 

--- a/BuscaMissa/DTOs/v1/EmailEventoIgrejaDto/RegistrarContatoRequest.cs
+++ b/BuscaMissa/DTOs/v1/EmailEventoIgrejaDto/RegistrarContatoRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+using BuscaMissa.Enums;
+
+namespace BuscaMissa.DTOs.v1.EmailEventoIgrejaDto;
+
+public class RegistrarContatoRequest
+{
+    [Required] public int IgrejaId { get; set; }
+
+    [Required] public TipoEmailEventoIgrejaEnum Tipo { get; set; }
+
+    [Required] public CanalContatoEnum Canal { get; set; }
+
+    [Required] [MaxLength(300)] public string DestinoContato { get; set; } = string.Empty;
+
+    [Required] public DateTime DataEnvio { get; set; }
+
+    [MaxLength(500)] public string? Observacao { get; set; }
+}

--- a/BuscaMissa/Enums/CanalContatoEnum.cs
+++ b/BuscaMissa/Enums/CanalContatoEnum.cs
@@ -1,0 +1,8 @@
+namespace BuscaMissa.Enums;
+
+public enum CanalContatoEnum
+{
+    Email = 1,
+    Instagram = 2,
+    Facebook = 3
+}

--- a/BuscaMissa/Migrations/20260701123751_adicionar_canal_destino_email_evento.Designer.cs
+++ b/BuscaMissa/Migrations/20260701123751_adicionar_canal_destino_email_evento.Designer.cs
@@ -4,6 +4,7 @@ using BuscaMissa.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BuscaMissa.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701123751_adicionar_canal_destino_email_evento")]
+    partial class adicionar_canal_destino_email_evento
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BuscaMissa/Migrations/20260701123751_adicionar_canal_destino_email_evento.cs
+++ b/BuscaMissa/Migrations/20260701123751_adicionar_canal_destino_email_evento.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BuscaMissa.Migrations
+{
+    /// <inheritdoc />
+    public partial class adicionar_canal_destino_email_evento : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Canal",
+                table: "EmailEventosIgreja",
+                type: "int",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DestinoContato",
+                table: "EmailEventosIgreja",
+                type: "varchar(300)",
+                maxLength: 300,
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Canal",
+                table: "EmailEventosIgreja");
+
+            migrationBuilder.DropColumn(
+                name: "DestinoContato",
+                table: "EmailEventosIgreja");
+        }
+    }
+}

--- a/BuscaMissa/Models/EmailEventoIgreja.cs
+++ b/BuscaMissa/Models/EmailEventoIgreja.cs
@@ -34,4 +34,8 @@ public class EmailEventoIgreja
     public DateTime? DataAlteracao { get; set; }
 
     [MaxLength(500)] public string? Observacao { get; set; }
+
+    public CanalContatoEnum Canal { get; set; } = CanalContatoEnum.Email;
+
+    [MaxLength(300)] public string? DestinoContato { get; set; }
 }

--- a/BuscaMissa/Services/v1/EmailEventoIgrejaService.cs
+++ b/BuscaMissa/Services/v1/EmailEventoIgrejaService.cs
@@ -49,8 +49,17 @@ public class EmailEventoIgrejaService(
         if (filtro.IgrejaId.HasValue)
             query = query.Where(x => x.IgrejaId == filtro.IgrejaId.Value);
 
+        if (!string.IsNullOrWhiteSpace(filtro.IgrejaNome))
+            query = query.Where(x => x.Igreja.Nome.Contains(filtro.IgrejaNome));
+
+        if (!string.IsNullOrWhiteSpace(filtro.Cidade))
+            query = query.Where(x => x.Igreja.Endereco.Localidade.Contains(filtro.Cidade));
+
         if (filtro.Tipo.HasValue)
             query = query.Where(x => x.Tipo == filtro.Tipo.Value);
+
+        if (filtro.Canal.HasValue)
+            query = query.Where(x => x.Canal == filtro.Canal.Value);
 
         if (!string.IsNullOrWhiteSpace(filtro.EmailDestino))
             query = query.Where(x => x.EmailDestino.Contains(filtro.EmailDestino));
@@ -60,6 +69,12 @@ public class EmailEventoIgrejaService(
 
         if (filtro.Enviado.HasValue)
             query = query.Where(x => x.Enviado == filtro.Enviado.Value);
+
+        if (filtro.DataEnvioInicio.HasValue)
+            query = query.Where(x => x.DataEnvio >= filtro.DataEnvioInicio.Value);
+
+        if (filtro.DataEnvioFim.HasValue)
+            query = query.Where(x => x.DataEnvio <= filtro.DataEnvioFim.Value);
 
         if (filtro.DataCriacaoInicio.HasValue)
             query = query.Where(x => x.DataCriacao >= filtro.DataCriacaoInicio.Value);
@@ -92,6 +107,7 @@ public class EmailEventoIgrejaService(
             {
                 IgrejaId = request.IgrejaId,
                 Tipo = request.Tipo,
+                Canal = CanalContatoEnum.Email,
                 Assunto = request.Assunto,
                 EmailDestino = request.EmailDestino,
                 NomeDestino = request.NomeDestino,
@@ -111,6 +127,38 @@ public class EmailEventoIgrejaService(
         catch (Exception ex)
         {
             logger.LogError(ex, "Erro ao inserir evento de e-mail da igreja {IgrejaId}", request.IgrejaId);
+            throw;
+        }
+    }
+
+    public async Task<EmailEventoIgreja> RegistrarContatoAsync(RegistrarContatoRequest request)
+    {
+        try
+        {
+            var model = new EmailEventoIgreja
+            {
+                IgrejaId = request.IgrejaId,
+                Tipo = request.Tipo,
+                Canal = request.Canal,
+                DestinoContato = request.DestinoContato,
+                Assunto = string.Empty,
+                EmailDestino = string.Empty,
+                Html = string.Empty,
+                Ativo = true,
+                Enviado = true,
+                DataEnvio = request.DataEnvio,
+                Observacao = request.Observacao,
+                DataCriacao = DateTime.UtcNow
+            };
+
+            context.Set<EmailEventoIgreja>().Add(model);
+            await context.SaveChangesAsync();
+
+            return model;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Erro ao registrar contato manual da igreja {IgrejaId}", request.IgrejaId);
             throw;
         }
     }


### PR DESCRIPTION
## Summary

- Adiciona `CanalContatoEnum` (Email=1, Instagram=2, Facebook=3) e migration com colunas `Canal` e `DestinoContato` na tabela `EmailEventosIgreja`
- Novo endpoint `POST /api/v1/Admin/email-evento/registrar-contato` com `RegistrarContatoRequest` — sem campos de e-mail, separando os dois fluxos de negócio
- Filtros de busca evoluídos: `IgrejaNome`, `Cidade`, `Canal`, `DataEnvioInicio/Fim`
- DTO de resposta enriquecido com `IgrejaUf`, `IgrejaCidadeSlug`, `IgrejaSlug` para construção do link público

## Test plan

- [ ] Migration aplica sem erros ao subir a aplicação
- [ ] `POST /registrar-contato` grava registro com `Canal=Instagram/Facebook` sem exigir Assunto/Html/EmailDestino
- [ ] `POST /criar` continua validando Assunto, Html e EmailDestino normalmente
- [ ] Filtros de busca retornam resultados corretos por canal, cidade e data de envio

🤖 Generated with [Claude Code](https://claude.com/claude-code)