### PR TITLE
feat: novo módulo de Divulgação das Igrejas

### DIFF
--- a/BuscaMissa/Controllers/v1/AdminController.cs
+++ b/BuscaMissa/Controllers/v1/AdminController.cs
@@ -15,6 +15,7 @@ using BuscaMissa.Services.v1;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using BuscaMissa.DTOs.v1.EmailEventoIgrejaDto;
+using BuscaMissa.DTOs.v1.DivulgacaoDto;
 
 namespace BuscaMissa.Controllers.v1
 {
@@ -29,6 +30,7 @@ namespace BuscaMissa.Controllers.v1
         ViaCepService viaCepService,
         IConfiguration configuration,
         EmailEventoIgrejaService emailEventoIgrejaService,
+        DivulgacaoService divulgacaoService,
         BuscaMissa.Services.ServicoConsultaMetricas servicoConsultaMetricas
         ) : ControllerBase
     {
@@ -157,7 +159,7 @@ namespace BuscaMissa.Controllers.v1
 
                 igreja = await igrejaService.EditarAsync(igreja);
 
-                await EnviarEmailAsync(igreja);
+                await divulgacaoService.EnviarEmailAsync(igreja, true);
 
                 var response = (IgrejaResponse)igreja;
                 response.EmailCriacaoEnviado = await emailEventoIgrejaService.EmailCriacaoJaEnviadoAsync(igreja.Id);
@@ -234,7 +236,7 @@ namespace BuscaMissa.Controllers.v1
                     !string.IsNullOrWhiteSpace(request.Contato?.EmailContato))
                 {
                     var tipo = request.TipoEmailContato.Contains("criacao") ? true : false;
-                    await  EnviarEmailAsync(igreja, tipo);
+                    await divulgacaoService.EnviarEmailAsync(igreja, tipo);
                 }
 
                 var response = (IgrejaResponse)igreja;
@@ -679,133 +681,60 @@ namespace BuscaMissa.Controllers.v1
 
         #endregion
 
-        private async Task EnviarEmailAsync(Igreja igreja, bool criacao = true)
-        {
-            var emailContato = igreja.Contato?.EmailContato;
-            var html = string.Empty;
-            var assunto = string.Empty;
-            var tipoEvento = criacao
-                ? TipoEmailEventoIgrejaEnum.Criacao
-                : TipoEmailEventoIgrejaEnum.Alteracao;
+        #region Divulgacao
 
+        [HttpGet]
+        [Route("divulgacao/dashboard")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> DivulgacaoDashboard()
+        {
             try
             {
-                if (string.IsNullOrWhiteSpace(emailContato))
-                    return;
-
-                var url = string.Concat(
-                    FrontendBaseUrl,
-                    "/paroquia/",
-                    igreja.Endereco.Uf.ToLower(),
-                    "/",
-                    igreja.Endereco.CidadeSlug,
-                    "/",
-                    igreja.Slug
-                );
-
-                if (criacao)
-                {
-                    assunto = $"#Busca Missa - Cadastro da igreja {igreja.Nome}";
-
-                    html = EmailHtmlGenerator.GerarHtmlEmailCriacao(
-                        igreja.Nome,
-                        igreja.Endereco.Logradouro,
-                        igreja.Endereco.Numero,
-                        igreja.Endereco.Bairro,
-                        igreja.Endereco.Localidade,
-                        igreja.Endereco.Estado,
-                        igreja.Paroco,
-                        url
-                    );
-                }
-                else
-                {
-                    assunto = $"#Busca Missa - Atualização das informações da igreja {igreja.Nome}";
-
-                    html = EmailHtmlGenerator.GerarHtmlEmailAlteracao(
-                        igreja.Nome,
-                        igreja.Endereco.Logradouro,
-                        igreja.Endereco.Numero,
-                        igreja.Endereco.Bairro,
-                        igreja.Endereco.Localidade,
-                        igreja.Endereco.Estado,
-                        igreja.Paroco,
-                        url
-                    );
-                }
-
-                var responseEmail = await emailService.EnviarEmail(
-                    [emailContato],
-                    assunto,
-                    html
-                );
-
-                var enviado = !string.IsNullOrWhiteSpace(responseEmail);
-
-                await emailEventoIgrejaService.InserirAsync(new CriarEmailEventoIgrejaRequest
-                {
-                    IgrejaId = igreja.Id,
-                    Tipo = tipoEvento,
-                    Assunto = assunto,
-                    EmailDestino = emailContato,
-                    NomeDestino = igreja.Nome,
-                    Html = html,
-                    Ativo = true,
-                    Enviado = enviado,
-                    DataEnvio = enviado ? DateTime.UtcNow : null,
-                    Observacao = enviado
-                        ? "E-mail enviado automaticamente pelo fluxo administrativo."
-                        : "Tentativa automática de envio realizada, porém o serviço de e-mail não retornou confirmação."
-                });
-
-                if (!enviado)
-                {
-                    logger.LogWarning(
-                        "Igreja processada com sucesso, mas o e-mail não foi enviado. IgrejaId: {IgrejaId}, Email: {Email}",
-                        igreja.Id,
-                        emailContato
-                    );
-                }
+                var response = await divulgacaoService.ObterDashboardAsync();
+                return Ok(new ApiResponse<dynamic>(response));
             }
             catch (Exception ex)
             {
-                logger.LogError(
-                    ex,
-                    "Igreja processada com sucesso, mas ocorreu erro ao enviar ou registrar e-mail. IgrejaId: {IgrejaId}",
-                    igreja.Id
-                );
-
-                if (!string.IsNullOrWhiteSpace(emailContato))
-                {
-                    try
-                    {
-                        await emailEventoIgrejaService.InserirAsync(new CriarEmailEventoIgrejaRequest
-                        {
-                            IgrejaId = igreja.Id,
-                            Tipo = tipoEvento,
-                            Assunto = string.IsNullOrWhiteSpace(assunto)
-                                ? $"Notificação da igreja {igreja.Nome}"
-                                : assunto,
-                            EmailDestino = emailContato,
-                            NomeDestino = igreja.Nome,
-                            Html = html,
-                            Ativo = true,
-                            Enviado = false,
-                            DataEnvio = null,
-                            Observacao = $"Erro ao enviar ou registrar e-mail: {ex.Message}"
-                        });
-                    }
-                    catch (Exception eventoEx)
-                    {
-                        logger.LogError(
-                            eventoEx,
-                            "Erro ao registrar falha de evento de e-mail. IgrejaId: {IgrejaId}",
-                            igreja.Id
-                        );
-                    }
-                }
+                logger.LogError("{Ex}", ex);
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
+        [HttpGet]
+        [Route("divulgacao/igrejas")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> DivulgacaoIgrejas([FromQuery] FiltroIgrejaDivulgacaoRequest filtro)
+        {
+            try
+            {
+                var response = await divulgacaoService.BuscarIgrejasAsync(filtro);
+                return Ok(new ApiResponse<dynamic>(response));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [HttpPost]
+        [Route("divulgacao/enviar-email-lote")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> DivulgacaoEnviarEmailLote([FromBody] EnviarEmailLoteRequest request)
+        {
+            try
+            {
+                if (!ModelState.IsValid) return BadRequest();
+                var response = await divulgacaoService.EnviarEmailLoteAsync(request);
+                return Ok(new ApiResponse<dynamic>(response));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        #endregion
     }
 }

--- a/BuscaMissa/Controllers/v1/CodigoValidadorController.cs
+++ b/BuscaMissa/Controllers/v1/CodigoValidadorController.cs
@@ -1,7 +1,6 @@
 using BuscaMissa.Constants;
 using BuscaMissa.DTOs;
 using BuscaMissa.DTOs.ControleDto;
-using BuscaMissa.DTOs.v1.EmailHtmlGenerator;
 using BuscaMissa.Helpers;
 using BuscaMissa.Models;
 using BuscaMissa.Services.v1;
@@ -14,11 +13,11 @@ namespace BuscaMissa.Controllers.v1
     [Route("api/v{version:apiVersion}/[controller]")]
     public class CodigoValidadorController(ILogger<CodigoValidadorController> logger, EmailService emailService, UsuarioService usuarioService,
     IgrejaService igrejaService, ControleService controleService, CodigoValidacaoService codigoValidacaoService, IgrejaTemporariaService igrejaTemporariaService,
+    DivulgacaoService divulgacaoService,
     IConfiguration configuration)
     : ControllerBase
     {
-        private string FrontendBaseUrl => configuration["FrontendBaseUrl"] ?? "https://buscamissa.com.br";
-        
+
         [HttpPost]
         [Route("validar-igreja")]
         [Authorize(Roles = "App")]
@@ -43,14 +42,14 @@ namespace BuscaMissa.Controllers.v1
                         case Enums.StatusEnum.Igreja_Criacao_Aguardando_Codigo_Validador:
                             await igrejaService.AtivarAsync(controle, usuario);
                             if(controle.Igreja.Contato is not null)
-                                await EnviarEmail(controle.Igreja);
+                                await divulgacaoService.EnviarEmailAsync(controle.Igreja, true);
                             break;
                         case Enums.StatusEnum.Igreja_Atualizacao_Aguardando_Codigo_Validador:
                             var temporaria = await igrejaTemporariaService.BuscarPorIgrejaIdAsync(controle.Igreja.Id);
                             await igrejaService.EditarPorTemporariaAsync(controle.Igreja, temporaria!);
                             await igrejaService.AtivarAsync(controle, usuario);
                             if(controle.Igreja.Contato is not null)
-                                await EnviarEmail(controle.Igreja);
+                                await divulgacaoService.EnviarEmailAsync(controle.Igreja, false);
                             break;
                         default:
                             return BadRequest(new ApiResponse<dynamic>(new { mensagemTela = "Não há validação para esta operação!" }));
@@ -91,54 +90,6 @@ namespace BuscaMissa.Controllers.v1
                 logger.LogError("{Ex}", ex);
                 var response = new ApiResponse<dynamic>(ex.Message);
                 return StatusCode(StatusCodes.Status500InternalServerError, response);
-            }
-        }
-        
-        private async Task EnviarEmail(Igreja igreja, bool criacao = true)
-        {
-            try
-            {
-                var url = string.Concat(FrontendBaseUrl, "/paroquia/", igreja.Endereco.Uf.ToLower(), "/", igreja.Endereco.CidadeSlug, "/", igreja.NomeUnico);
-                string assunto;
-                string htmlEmail;
-                if (criacao)
-                {
-                    // Gerar o HTML para criação
-                    htmlEmail = EmailHtmlGenerator.GerarHtmlEmailCriacao(
-                        igreja.Nome, 
-                        igreja.Endereco.Logradouro, 
-                        igreja.Endereco.Numero, 
-                        igreja.Endereco.Bairro, 
-                        igreja.Endereco.Localidade, 
-                        igreja.Endereco.Estado,
-                        igreja.Paroco,
-                        url
-                    );
-                    assunto= $"Sua Igreja {igreja.Nome} foi cadastrada no Busca Missa!";
-                }
-                else
-                {
-                    // Gerar o HTML para alteração
-                    htmlEmail = EmailHtmlGenerator.GerarHtmlEmailCriacao(
-                        igreja.Nome, 
-                        igreja.Endereco.Logradouro, 
-                        igreja.Endereco.Numero, 
-                        igreja.Endereco.Bairro, 
-                        igreja.Endereco.Localidade, 
-                        igreja.Endereco.Estado,
-                        igreja.Paroco,
-                        url
-                    );
-                    assunto = $"Atualização das informações da igreja {igreja.Nome} no Busca Missa";
-
-                }
-            
-                await emailService.EnviarEmail(new[] { igreja.Contato?.EmailContato! }, assunto, htmlEmail);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                
             }
         }
     }

--- a/BuscaMissa/DTOs/v1/DivulgacaoDto/DivulgacaoDashboardResponse.cs
+++ b/BuscaMissa/DTOs/v1/DivulgacaoDto/DivulgacaoDashboardResponse.cs
@@ -1,0 +1,14 @@
+namespace BuscaMissa.DTOs.v1.DivulgacaoDto;
+
+public class DivulgacaoDashboardResponse
+{
+    public int TotalIgrejas { get; set; }
+
+    public int SemContatoEmail { get; set; }
+
+    public int SemEmailAlteracaoPendente { get; set; }
+
+    public int SemContatoFacebook { get; set; }
+
+    public int SemContatoInstagram { get; set; }
+}

--- a/BuscaMissa/DTOs/v1/DivulgacaoDto/EnviarEmailLoteRequest.cs
+++ b/BuscaMissa/DTOs/v1/DivulgacaoDto/EnviarEmailLoteRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BuscaMissa.DTOs.v1.DivulgacaoDto;
+
+public class EnviarEmailLoteRequest
+{
+    [Required(ErrorMessage = "{0} é obrigatório!")]
+    public List<int> IgrejaIds { get; set; } = [];
+
+    [Required(ErrorMessage = "{0} é obrigatório!")]
+    public string Tipo { get; set; } = null!;
+}

--- a/BuscaMissa/DTOs/v1/DivulgacaoDto/EnviarEmailLoteResponse.cs
+++ b/BuscaMissa/DTOs/v1/DivulgacaoDto/EnviarEmailLoteResponse.cs
@@ -1,0 +1,19 @@
+namespace BuscaMissa.DTOs.v1.DivulgacaoDto;
+
+public class EnviarEmailLoteResponse
+{
+    public int TotalSolicitado { get; set; }
+
+    public int TotalEnviado { get; set; }
+
+    public List<EnvioLoteFalhaResponse> Falhas { get; set; } = [];
+}
+
+public class EnvioLoteFalhaResponse
+{
+    public int IgrejaId { get; set; }
+
+    public string? Nome { get; set; }
+
+    public string Motivo { get; set; } = null!;
+}

--- a/BuscaMissa/DTOs/v1/DivulgacaoDto/FiltroIgrejaDivulgacaoRequest.cs
+++ b/BuscaMissa/DTOs/v1/DivulgacaoDto/FiltroIgrejaDivulgacaoRequest.cs
@@ -1,0 +1,15 @@
+using BuscaMissa.DTOs.PaginacaoDto;
+using BuscaMissa.Enums;
+
+namespace BuscaMissa.DTOs.v1.DivulgacaoDto;
+
+public class FiltroIgrejaDivulgacaoRequest : PaginacaoRequest
+{
+    public ModoDivulgacaoEnum Modo { get; set; }
+
+    public string? Nome { get; set; }
+
+    public string? Cidade { get; set; }
+
+    public string? Uf { get; set; }
+}

--- a/BuscaMissa/DTOs/v1/DivulgacaoDto/IgrejaDivulgacaoResponse.cs
+++ b/BuscaMissa/DTOs/v1/DivulgacaoDto/IgrejaDivulgacaoResponse.cs
@@ -1,0 +1,32 @@
+namespace BuscaMissa.DTOs.v1.DivulgacaoDto;
+
+public class IgrejaDivulgacaoResponse
+{
+    public int Id { get; set; }
+
+    public string Nome { get; set; } = null!;
+
+    public string? Cidade { get; set; }
+
+    public string? CidadeSlug { get; set; }
+
+    public string? Uf { get; set; }
+
+    public string? Slug { get; set; }
+
+    public string? Email { get; set; }
+
+    public string? Instagram { get; set; }
+
+    public string? Facebook { get; set; }
+
+    public DateTime Criacao { get; set; }
+
+    public DateTime Alteracao { get; set; }
+
+    public DateTime? UltimoContatoEmail { get; set; }
+
+    public DateTime? UltimoContatoFacebook { get; set; }
+
+    public DateTime? UltimoContatoInstagram { get; set; }
+}

--- a/BuscaMissa/DTOs/v1/IgrejaDto/ContatoIgrejaRequest.cs
+++ b/BuscaMissa/DTOs/v1/IgrejaDto/ContatoIgrejaRequest.cs
@@ -9,7 +9,7 @@ namespace BuscaMissa.DTOs.IgrejaDto
         public string? EmailContato { get; set; }
         [RegularExpression(@"^\d{2}$", ErrorMessage = "DDD deve conter apenas números e ter 2 dígitos.")]
         public string? DDD { get; set; }
-        [RegularExpression(@"^\d{8}$", ErrorMessage = "O Telefone deve conter apenas números e ter 8 dígitos.")]
+        [RegularExpression(@"^\d{8,9}$", ErrorMessage = "O Telefone deve conter apenas números e ter 8 ou 9 dígitos.")]
         public string? Telefone { get; set; }
         [RegularExpression(@"^\d{2}$", ErrorMessage = "DDDWhatsApp deve conter apenas números e ter 2 dígitos.")]
         public string? DDDWhatsApp { get; set; }

--- a/BuscaMissa/Enums/ModoDivulgacaoEnum.cs
+++ b/BuscaMissa/Enums/ModoDivulgacaoEnum.cs
@@ -1,0 +1,9 @@
+namespace BuscaMissa.Enums;
+
+public enum ModoDivulgacaoEnum
+{
+    SemContatoEmail = 1,
+    SemEmailAlteracaoPendente = 2,
+    SemContatoFacebook = 3,
+    SemContatoInstagram = 4
+}

--- a/BuscaMissa/Program.cs
+++ b/BuscaMissa/Program.cs
@@ -82,6 +82,7 @@ builder.Services.AddScoped<ServicoModeracaoComentarios>();
 builder.Services.AddScoped<ServicoEngajamentoIgreja>();
 builder.Services.AddScoped<ConfiabilidadeService>();
 builder.Services.AddScoped<EmailEventoIgrejaService>();
+builder.Services.AddScoped<DivulgacaoService>();
 builder.Services.AddScoped<IMetricaDiariaRepositorio, MetricaDiariaRepositorio>();
 builder.Services.AddScoped<BuscaMissa.Services.ServicoMetricas>();
 builder.Services.AddScoped<BuscaMissa.Services.ServicoConsultaMetricas>();

--- a/BuscaMissa/Services/v1/DivulgacaoService.cs
+++ b/BuscaMissa/Services/v1/DivulgacaoService.cs
@@ -1,0 +1,308 @@
+using BuscaMissa.Context;
+using BuscaMissa.DTOs.PaginacaoDto;
+using BuscaMissa.DTOs.v1.DivulgacaoDto;
+using BuscaMissa.DTOs.v1.EmailEventoIgrejaDto;
+using BuscaMissa.DTOs.v1.EmailHtmlGenerator;
+using BuscaMissa.Enums;
+using BuscaMissa.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BuscaMissa.Services.v1;
+
+public class DivulgacaoService(
+    ApplicationDbContext context,
+    EmailService emailService,
+    EmailEventoIgrejaService emailEventoIgrejaService,
+    ILogger<DivulgacaoService> logger,
+    IConfiguration configuration)
+{
+    private string FrontendBaseUrl => configuration["FrontendBaseUrl"] ?? "https://buscamissa.com.br";
+
+    public async Task<DivulgacaoDashboardResponse> ObterDashboardAsync()
+    {
+        var totalIgrejas = await context.Igrejas.AsNoTracking().CountAsync(x => x.Ativo);
+
+        return new DivulgacaoDashboardResponse
+        {
+            TotalIgrejas = totalIgrejas,
+            SemContatoEmail = await AplicarModo(ModoDivulgacaoEnum.SemContatoEmail).CountAsync(),
+            SemEmailAlteracaoPendente = await AplicarModo(ModoDivulgacaoEnum.SemEmailAlteracaoPendente).CountAsync(),
+            SemContatoFacebook = await AplicarModo(ModoDivulgacaoEnum.SemContatoFacebook).CountAsync(),
+            SemContatoInstagram = await AplicarModo(ModoDivulgacaoEnum.SemContatoInstagram).CountAsync(),
+        };
+    }
+
+    public async Task<Paginacao<IgrejaDivulgacaoResponse>> BuscarIgrejasAsync(FiltroIgrejaDivulgacaoRequest filtro)
+    {
+        var query = AplicarModo(filtro.Modo);
+
+        if (!string.IsNullOrWhiteSpace(filtro.Nome))
+            query = query.Where(x => x.Nome.Contains(filtro.Nome));
+
+        if (!string.IsNullOrWhiteSpace(filtro.Cidade))
+            query = query.Where(x => x.Endereco.Localidade.Contains(filtro.Cidade));
+
+        if (!string.IsNullOrWhiteSpace(filtro.Uf))
+            query = query.Where(x => x.Endereco.Uf == filtro.Uf);
+
+        var total = await query.CountAsync();
+
+        var itens = await query
+            .OrderBy(x => x.Nome)
+            .Skip((filtro.PageIndex - 1) * filtro.PageSize)
+            .Take(filtro.PageSize)
+            .Select(x => new IgrejaDivulgacaoResponse
+            {
+                Id = x.Id,
+                Nome = x.Nome,
+                Cidade = x.Endereco.Localidade,
+                CidadeSlug = x.Endereco.CidadeSlug,
+                Uf = x.Endereco.Uf,
+                Slug = x.Slug,
+                Email = x.Contato != null ? x.Contato.EmailContato : null,
+                Instagram = x.RedesSociais!
+                    .Where(r => r.TipoRedeSocial == TipoRedeSocialEnum.Instagram)
+                    .Select(r => r.NomeDoPerfil)
+                    .FirstOrDefault(),
+                Facebook = x.RedesSociais!
+                    .Where(r => r.TipoRedeSocial == TipoRedeSocialEnum.Facebook)
+                    .Select(r => r.NomeDoPerfil)
+                    .FirstOrDefault(),
+                Criacao = x.Criacao,
+                Alteracao = x.Alteracao,
+                UltimoContatoEmail = context.EmailEventosIgreja
+                    .Where(e => e.IgrejaId == x.Id && e.Canal == CanalContatoEnum.Email && e.Enviado)
+                    .OrderByDescending(e => e.DataEnvio)
+                    .Select(e => e.DataEnvio)
+                    .FirstOrDefault(),
+                UltimoContatoFacebook = context.EmailEventosIgreja
+                    .Where(e => e.IgrejaId == x.Id && e.Canal == CanalContatoEnum.Facebook && e.Enviado)
+                    .OrderByDescending(e => e.DataEnvio)
+                    .Select(e => e.DataEnvio)
+                    .FirstOrDefault(),
+                UltimoContatoInstagram = context.EmailEventosIgreja
+                    .Where(e => e.IgrejaId == x.Id && e.Canal == CanalContatoEnum.Instagram && e.Enviado)
+                    .OrderByDescending(e => e.DataEnvio)
+                    .Select(e => e.DataEnvio)
+                    .FirstOrDefault(),
+            })
+            .ToListAsync();
+
+        return new Paginacao<IgrejaDivulgacaoResponse>(filtro.PageIndex, filtro.PageSize, total, itens);
+    }
+
+    private IQueryable<Igreja> AplicarModo(ModoDivulgacaoEnum modo)
+    {
+        var query = context.Igrejas
+            .AsNoTracking()
+            .Where(x => x.Ativo);
+
+        return modo switch
+        {
+            ModoDivulgacaoEnum.SemContatoEmail => query
+                .Where(x => x.Contato != null && x.Contato.EmailContato != null)
+                .Where(x => !context.EmailEventosIgreja.Any(e =>
+                    e.IgrejaId == x.Id && e.Canal == CanalContatoEnum.Email && e.Enviado)),
+
+            ModoDivulgacaoEnum.SemEmailAlteracaoPendente => query
+                .Where(x => x.Alteracao > x.Criacao)
+                .Where(x => x.Contato != null && x.Contato.EmailContato != null)
+                .Where(x => !context.EmailEventosIgreja.Any(e =>
+                    e.IgrejaId == x.Id &&
+                    e.Tipo == TipoEmailEventoIgrejaEnum.Alteracao &&
+                    e.Enviado &&
+                    e.DataEnvio >= x.Alteracao)),
+
+            ModoDivulgacaoEnum.SemContatoFacebook => query
+                .Where(x => x.RedesSociais!.Any(r => r.TipoRedeSocial == TipoRedeSocialEnum.Facebook))
+                .Where(x => !context.EmailEventosIgreja.Any(e =>
+                    e.IgrejaId == x.Id && e.Canal == CanalContatoEnum.Facebook && e.Enviado)),
+
+            ModoDivulgacaoEnum.SemContatoInstagram => query
+                .Where(x => x.RedesSociais!.Any(r => r.TipoRedeSocial == TipoRedeSocialEnum.Instagram))
+                .Where(x => !context.EmailEventosIgreja.Any(e =>
+                    e.IgrejaId == x.Id && e.Canal == CanalContatoEnum.Instagram && e.Enviado)),
+
+            _ => query
+        };
+    }
+
+    public async Task<bool> EnviarEmailAsync(Igreja igreja, bool criacao)
+    {
+        var emailContato = igreja.Contato?.EmailContato;
+        var html = string.Empty;
+        var assunto = string.Empty;
+        var tipoEvento = criacao
+            ? TipoEmailEventoIgrejaEnum.Criacao
+            : TipoEmailEventoIgrejaEnum.Alteracao;
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(emailContato))
+                return false;
+
+            var url = string.Concat(
+                FrontendBaseUrl,
+                "/paroquia/",
+                igreja.Endereco.Uf.ToLower(),
+                "/",
+                igreja.Endereco.CidadeSlug,
+                "/",
+                igreja.Slug
+            );
+
+            if (criacao)
+            {
+                assunto = $"#Busca Missa - Cadastro da igreja {igreja.Nome}";
+
+                html = EmailHtmlGenerator.GerarHtmlEmailCriacao(
+                    igreja.Nome,
+                    igreja.Endereco.Logradouro,
+                    igreja.Endereco.Numero,
+                    igreja.Endereco.Bairro,
+                    igreja.Endereco.Localidade,
+                    igreja.Endereco.Estado,
+                    igreja.Paroco,
+                    url
+                );
+            }
+            else
+            {
+                assunto = $"#Busca Missa - Atualização das informações da igreja {igreja.Nome}";
+
+                html = EmailHtmlGenerator.GerarHtmlEmailAlteracao(
+                    igreja.Nome,
+                    igreja.Endereco.Logradouro,
+                    igreja.Endereco.Numero,
+                    igreja.Endereco.Bairro,
+                    igreja.Endereco.Localidade,
+                    igreja.Endereco.Estado,
+                    igreja.Paroco,
+                    url
+                );
+            }
+
+            var responseEmail = await emailService.EnviarEmail(
+                [emailContato],
+                assunto,
+                html
+            );
+
+            var enviado = !string.IsNullOrWhiteSpace(responseEmail);
+
+            await emailEventoIgrejaService.InserirAsync(new CriarEmailEventoIgrejaRequest
+            {
+                IgrejaId = igreja.Id,
+                Tipo = tipoEvento,
+                Assunto = assunto,
+                EmailDestino = emailContato,
+                NomeDestino = igreja.Nome,
+                Html = html,
+                Ativo = true,
+                Enviado = enviado,
+                DataEnvio = enviado ? DateTime.UtcNow : null,
+                Observacao = enviado
+                    ? "E-mail enviado automaticamente pelo fluxo administrativo."
+                    : "Tentativa automática de envio realizada, porém o serviço de e-mail não retornou confirmação."
+            });
+
+            if (!enviado)
+            {
+                logger.LogWarning(
+                    "Igreja processada com sucesso, mas o e-mail não foi enviado. IgrejaId: {IgrejaId}, Email: {Email}",
+                    igreja.Id,
+                    emailContato
+                );
+            }
+
+            return enviado;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Igreja processada com sucesso, mas ocorreu erro ao enviar ou registrar e-mail. IgrejaId: {IgrejaId}",
+                igreja.Id
+            );
+
+            if (!string.IsNullOrWhiteSpace(emailContato))
+            {
+                try
+                {
+                    await emailEventoIgrejaService.InserirAsync(new CriarEmailEventoIgrejaRequest
+                    {
+                        IgrejaId = igreja.Id,
+                        Tipo = tipoEvento,
+                        Assunto = string.IsNullOrWhiteSpace(assunto)
+                            ? $"Notificação da igreja {igreja.Nome}"
+                            : assunto,
+                        EmailDestino = emailContato,
+                        NomeDestino = igreja.Nome,
+                        Html = html,
+                        Ativo = true,
+                        Enviado = false,
+                        DataEnvio = null,
+                        Observacao = $"Erro ao enviar ou registrar e-mail: {ex.Message}"
+                    });
+                }
+                catch (Exception eventoEx)
+                {
+                    logger.LogError(
+                        eventoEx,
+                        "Erro ao registrar falha de evento de e-mail. IgrejaId: {IgrejaId}",
+                        igreja.Id
+                    );
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public async Task<EnviarEmailLoteResponse> EnviarEmailLoteAsync(EnviarEmailLoteRequest request)
+    {
+        var criacao = request.Tipo.Contains("criacao", StringComparison.OrdinalIgnoreCase);
+
+        var igrejas = await context.Igrejas
+            .Include(x => x.Contato)
+            .Include(x => x.Endereco)
+            .Where(x => request.IgrejaIds.Contains(x.Id))
+            .ToListAsync();
+
+        var response = new EnviarEmailLoteResponse
+        {
+            TotalSolicitado = request.IgrejaIds.Count
+        };
+
+        foreach (var igreja in igrejas)
+        {
+            if (string.IsNullOrWhiteSpace(igreja.Contato?.EmailContato))
+            {
+                response.Falhas.Add(new EnvioLoteFalhaResponse
+                {
+                    IgrejaId = igreja.Id,
+                    Nome = igreja.Nome,
+                    Motivo = "Igreja não possui e-mail de contato cadastrado."
+                });
+                continue;
+            }
+
+            var enviado = await EnviarEmailAsync(igreja, criacao);
+            if (enviado)
+            {
+                response.TotalEnviado++;
+            }
+            else
+            {
+                response.Falhas.Add(new EnvioLoteFalhaResponse
+                {
+                    IgrejaId = igreja.Id,
+                    Nome = igreja.Nome,
+                    Motivo = "Falha ao enviar e-mail. Veja os logs para mais detalhes."
+                });
+            }
+        }
+
+        return response;
+    }
+}


### PR DESCRIPTION
## Resumo
- Cria os endpoints `GET /divulgacao/dashboard`, `GET /divulgacao/igrejas` e `POST /divulgacao/enviar-email-lote`, que o frontend admin já tentava chamar mas nunca existiram no backend (404).
- Novo `DivulgacaoService` calcula 4 indicadores de pendência por igreja: sem contato via e-mail (criação/alteração), alteração feita sem e-mail de alteração enviado (compara `Igreja.Alteracao` com o histórico), sem contato via Facebook e sem contato via Instagram (considerando apenas igrejas que já têm perfil cadastrado).
- `DivulgacaoService.EnviarEmailAsync` absorve a lógica de envio de e-mail de criação/alteração antes duplicada entre `AdminController` e `CodigoValidadorController`.
- Corrige bug real no fluxo público (`CodigoValidadorController`): o e-mail de criação/alteração era enviado mas nunca registrado em `EmailEventosIgreja`, e o template de "alteração" nunca era usado de fato (parâmetro `criacao` com default `true` nunca sobrescrito) — causava falsos positivos no indicador "sem contato via e-mail".
- Telefone fixo (`Contato.Telefone`) passa a aceitar 8 ou 9 dígitos, alinhado com o WhatsApp.

## Test plan
- [x] `dotnet build` sem erros
- [x] Validar manualmente os 3 novos endpoints com dados reais (dashboard, listagem por modo, envio em lote)
- [x] Confirmar no ambiente local que o fluxo público de validação por código passa a registrar o evento em `EmailEventosIgreja`

🤖 Generated with [Claude Code](https://claude.com/claude-code)