### PR TITLE
feat: suporte a redes sociais e geocodificação no lote

### DIFF
--- a/BuscaMissa/DTOs/v1/IgrejaDto/ImportacaoIgrejaLoteRequest.cs
+++ b/BuscaMissa/DTOs/v1/IgrejaDto/ImportacaoIgrejaLoteRequest.cs
@@ -1,3 +1,4 @@
+using BuscaMissa.DTOs.IgrejaDto;
 using BuscaMissa.Enums;
 
 namespace BuscaMissa.DTOs.v1.IgrejaDto;
@@ -38,6 +39,9 @@ public class ImportacaoIgrejaItemRequest
     // Coordenadas (geocodificadas) — localizam o ponto mesmo sem CEP
     public decimal? Latitude { get; set; }
     public decimal? Longitude { get; set; }
+
+    // Redes sociais da paróquia (opcional) — mesma validação/normalização do PUT admin
+    public IList<RedeSolcialIgrejaRequest>? RedesSociais { get; set; }
 }
 
 public class ImportacaoMissaRequest

--- a/BuscaMissa/Services/v1/IgrejaService.cs
+++ b/BuscaMissa/Services/v1/IgrejaService.cs
@@ -276,6 +276,13 @@ namespace BuscaMissa.Services.v1
                     var contato = CriarContato(item);
                     if (contato != null) igreja.Contato = contato;
 
+                    if (item.RedesSociais is { Count: > 0 })
+                    {
+                        igreja.RedesSociais = item.RedesSociais
+                            .Select(r => (RedeSocial)r)
+                            .ToList();
+                    }
+
                     context.Igrejas.Add(igreja);
                     await context.SaveChangesAsync();
                     chaves.Add(chaveNegocio); // evita reinserir a mesma igreja dentro do lote


### PR DESCRIPTION
## Resumo

Adiciona suporte a redes sociais e geocodificação no lote de importação de igrejas do BuscaMissa.

## Mudanças

- **Redes sociais no lote**: Campo `redesSociais` opcional em `ImportacaoIgrejaLoteRequest` reutiliza a mesma validação e normalização do PUT `admin/igreja/atualizar`
- **Adapter melhorado**: Captura URLs de redes sociais, converte em handles validados, impede rejection de lotes por handles inválidos
- **Geocodificação**: Interface com botão para preencher latitude/longitude via Nominatim (OpenStreetMap) antes do envio
- **Validação transparente**: Links clicáveis na etapa de validação para conferir dados contra a página de origem

## Detalhes da implementação

- `ImportacaoIgrejaLoteRequest.cs`: Campo `redesSociais` tipado como `IList<RedeSolcialIgrejaRequest>`
- `IgrejaService.cs`: Popula `igreja.RedesSociais` a partir do lote, usando o mesmo `explicit operator` do modelo
- Adapter valida handles com as regras do backend e reporta inválidos como avisos (não bloqueia o lote)

## Para testar

1. Enviar um lote com `redesSociais` preenchidas no Develop
2. Verificar que as redes sociais aparecem na Igreja criada
3. Confirmar que handles inválidos geram avisos (não param o lote)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)