### PR TITLE
fix: corrige lógica de alteração/remoção de imagem na atualização

### DIFF
--- a/BuscaMissa/Controllers/v1/AdminController.cs
+++ b/BuscaMissa/Controllers/v1/AdminController.cs
@@ -185,11 +185,23 @@ namespace BuscaMissa.Controllers.v1
                 var igreja = await igrejaService.BuscarPorIdAsync(request.Id);
                 if (igreja is null) return NotFound(new ApiResponse<dynamic>(new { messagemAplicacao = "Igreja não encontrada!" }));
 
-                if (!string.IsNullOrEmpty(request.Imagem))
+                // Tratar alteração de imagem
+                if (request.Imagem != null)
                 {
-                    igreja.ImagemUrl = $"{igreja.Id}{ImageHelper.BuscarExtensao(request.Imagem)}";
-                    imagemService.UploadAzure(request.Imagem, "igreja", igreja.ImagemUrl);
+                    if (string.IsNullOrEmpty(request.Imagem))
+                    {
+                        // Imagem foi removida explicitamente
+                        igreja.ImagemUrl = null;
+                        // TODO: deletar arquivo do Azure se necessário
+                    }
+                    else
+                    {
+                        // Nova imagem foi carregada
+                        igreja.ImagemUrl = $"{igreja.Id}{ImageHelper.BuscarExtensao(request.Imagem)}";
+                        imagemService.UploadAzure(request.Imagem, "igreja", igreja.ImagemUrl);
+                    }
                 }
+                // Se Imagem for null, não faz nada (mantém a imagem existente)
 
                 if (request.RedeSociais is not null)
                 {


### PR DESCRIPTION
## Descrição
Corrige o backend para permitir controle explícito sobre alteração, manutenção e remoção de imagens ao atualizar igrejas no painel admin.

## Problema
O backend não diferenciava entre "usuário não alterou a imagem" e "usuário quer remover a imagem", causando deleção acidental de imagens.

## Solução
Implementa lógica de três níveis:
- **Imagem nula**: não faz nada (mantém imagem existente)
- **Imagem vazia**: remove a imagem (seta ImagemUrl como null)
- **Imagem com base64**: faz upload da nova imagem

## Mudanças
- `Controllers/v1/AdminController.cs`: Lógica de tratamento de imagem no endpoint `PUT /api/v1/Admin/igreja/atualizar`

## Integração
Funciona em conjunto com as mudanças do frontend-admin (PR #60) que controla explicitamente o envio da imagem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)