### PR TITLE
feat: troca/reset de senha e melhorias na listagem de usuários

### DIFF
--- a/BuscaMissa/Constants/Constants.cs
+++ b/BuscaMissa/Constants/Constants.cs
@@ -14,6 +14,9 @@ public static class Constants
     public const string FrontendBaseUrlDefault = "https://buscamissa.com.br";
     // E-mail de suporte exibido ao usuário e usado como conta admin.
     public const string EmailSuporte = "suporte@buscamissa.com.br";
+    // Nome do secret no Key Vault que guarda a senha canônica do Admin (usado no login
+    // via SenhaHelper/DatabaseSeeder e re-sincronizado quando o Admin troca a própria senha).
+    public const string SecretNameSenhaAdmin = "SenhaAdmin";
 
     // Mensagem genérica para erros 500 — nunca retornar ex.Message ao cliente
     // (vaza detalhes internos). O erro completo vai para o log (Serilog).

--- a/BuscaMissa/Controllers/v1/AdminController.cs
+++ b/BuscaMissa/Controllers/v1/AdminController.cs
@@ -135,6 +135,46 @@ namespace BuscaMissa.Controllers.v1
             }
         }
 
+        [HttpGet]
+        [Route("usuario/{id}/igrejas")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> BuscarIgrejasDoUsuarioAsync(int id)
+        {
+            try
+            {
+                var igrejas = await usuarioService.BuscarIgrejasDoUsuarioAsync(id);
+                return Ok(new ApiResponse<dynamic>(new { total = igrejas.Count, igrejas }));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                var response = new ApiResponse<dynamic>(BuscaMissa.Constants.Constants.MensagemErroInterno);
+                return StatusCode(StatusCodes.Status500InternalServerError, response);
+            }
+        }
+
+        [HttpPut]
+        [Route("usuario/resetar-senha/{id}")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> ResetarSenhaAsync(int id, [FromBody] ResetarSenhaRequest request)
+        {
+            try
+            {
+                if (!ModelState.IsValid) return BadRequest(ModelState);
+                var model = await usuarioService.BuscarPorCodigo(id);
+                if (model == null) return NotFound(new ApiResponse<dynamic>("Usuário não encontrado"));
+
+                await usuarioService.ResetarSenhaAsync(model, request.NovaSenha);
+                return Ok(new ApiResponse<dynamic>(new { mensagemTela = "Senha resetada com sucesso!" }));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                var response = new ApiResponse<dynamic>(BuscaMissa.Constants.Constants.MensagemErroInterno);
+                return StatusCode(StatusCodes.Status500InternalServerError, response);
+            }
+        }
+
         #endregion
 
         #region Igreja

--- a/BuscaMissa/Controllers/v1/UsuarioController.cs
+++ b/BuscaMissa/Controllers/v1/UsuarioController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using BuscaMissa.Constants;
 using BuscaMissa.DTOs;
 using BuscaMissa.DTOs.UsuarioDto;
@@ -97,6 +98,31 @@ namespace BuscaMissa.Controllers.v1
                     codigoValidador = codigoValidador.CodigoToken
 #endif
                 }));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("{Ex}", ex);
+                var response = new ApiResponse<dynamic>(BuscaMissa.Constants.Constants.MensagemErroInterno);
+                return StatusCode(StatusCodes.Status500InternalServerError, response);
+            }
+        }
+
+        [HttpPut]
+        [Route("trocar-senha")]
+        [Authorize]
+        public async Task<IActionResult> TrocarSenha([FromBody] TrocarSenhaRequest request)
+        {
+            try
+            {
+                if (!ModelState.IsValid) return BadRequest(ModelState);
+                var email = User.FindFirstValue(ClaimTypes.Email);
+                var usuario = await _usuarioService.BuscarPorEmailAsync(email!);
+                if (usuario == null) return BadRequest(new ApiResponse<dynamic>(new { mensagemTela = "Usuário não existe!" }));
+
+                var alterado = await _usuarioService.TrocarSenhaAsync(usuario, request.SenhaAtual, request.NovaSenha);
+                if (!alterado) return BadRequest(new ApiResponse<dynamic>(new { mensagemTela = "Senha atual inválida!" }));
+
+                return Ok(new ApiResponse<dynamic>(new { mensagemTela = "Senha alterada com sucesso!" }));
             }
             catch (Exception ex)
             {

--- a/BuscaMissa/DTOs/v1/UsuarioDto/IgrejaResumoResponse.cs
+++ b/BuscaMissa/DTOs/v1/UsuarioDto/IgrejaResumoResponse.cs
@@ -1,0 +1,10 @@
+namespace BuscaMissa.DTOs.UsuarioDto
+{
+    public class IgrejaResumoResponse
+    {
+        public int Id { get; set; }
+        public string Nome { get; set; } = default!;
+        public string? Uf { get; set; }
+        public string? Localidade { get; set; }
+    }
+}

--- a/BuscaMissa/DTOs/v1/UsuarioDto/ResetarSenhaRequest.cs
+++ b/BuscaMissa/DTOs/v1/UsuarioDto/ResetarSenhaRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BuscaMissa.DTOs.UsuarioDto
+{
+    public class ResetarSenhaRequest
+    {
+        [Required(ErrorMessage = "{0} é obrigatório!")]
+        [MinLength(6, ErrorMessage = "{0} deve ter no mínimo {1} caracteres.")]
+        public string NovaSenha { get; set; } = default!;
+    }
+}

--- a/BuscaMissa/DTOs/v1/UsuarioDto/TrocarSenhaRequest.cs
+++ b/BuscaMissa/DTOs/v1/UsuarioDto/TrocarSenhaRequest.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BuscaMissa.DTOs.UsuarioDto
+{
+    public class TrocarSenhaRequest
+    {
+        [Required(ErrorMessage = "{0} é obrigatório!")]
+        public string SenhaAtual { get; set; } = default!;
+
+        [Required(ErrorMessage = "{0} é obrigatório!")]
+        [MinLength(6, ErrorMessage = "{0} deve ter no mínimo {1} caracteres.")]
+        public string NovaSenha { get; set; } = default!;
+    }
+}

--- a/BuscaMissa/DTOs/v1/UsuarioDto/UsuarioFiltroRequest.cs
+++ b/BuscaMissa/DTOs/v1/UsuarioDto/UsuarioFiltroRequest.cs
@@ -1,4 +1,5 @@
 using BuscaMissa.DTOs.PaginacaoDto;
+using BuscaMissa.Enums;
 
 namespace BuscaMissa.DTOs.UsuarioDto
 {
@@ -7,6 +8,9 @@ namespace BuscaMissa.DTOs.UsuarioDto
         public string? Nome { get; set; }
         public string? Email { get; set; }
         public bool? Bloqueado { get; set; }
+        public PerfilEnum? Perfil { get; set; }
+        public DateTime? CriacaoInicio { get; set; }
+        public DateTime? CriacaoFim { get; set; }
         public PaginacaoRequest Paginacao { get; set; } = default!;
     }
 }

--- a/BuscaMissa/Models/Usuario.cs
+++ b/BuscaMissa/Models/Usuario.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using BuscaMissa.DTOs.UsuarioDto;
 using BuscaMissa.Enums;
 
@@ -8,6 +9,9 @@ namespace BuscaMissa.Models
     {
         [Key]
         public int Id { get; set; }
+        // Preenchido só na projeção de listagem (BuscarPorFiltroAsync); não é coluna do banco.
+        [NotMapped]
+        public int TotalIgrejas { get; set; }
         [Required]
         public string Nome { get; set; } = null!;
         [Required]

--- a/BuscaMissa/Program.cs
+++ b/BuscaMissa/Program.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Threading.RateLimiting;
 using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
 using BuscaMissa.Context;
 using BuscaMissa.DTOs;
 using BuscaMissa.DTOs.SettingsDto;
@@ -42,6 +43,7 @@ builder.Configuration.AddAzureKeyVault(
     new Uri(keyVaultUri),
     new DefaultAzureCredential()
 );
+builder.Services.AddSingleton(new SecretClient(new Uri(keyVaultUri), new DefaultAzureCredential()));
 
 var secret = builder.Configuration["SecretApp"];
 var key = Encoding.ASCII.GetBytes(secret!);

--- a/BuscaMissa/Services/v1/UsuarioService.cs
+++ b/BuscaMissa/Services/v1/UsuarioService.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using Azure.Security.KeyVault.Secrets;
 using BuscaMissa.Context;
 using BuscaMissa.DTOs.PaginacaoDto;
 using BuscaMissa.DTOs.UsuarioDto;
@@ -11,11 +12,12 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace BuscaMissa.Services.v1
 {
-    public class UsuarioService(ApplicationDbContext context, ILogger<UsuarioService> logger, IConfiguration configuration)
+    public class UsuarioService(ApplicationDbContext context, ILogger<UsuarioService> logger, IConfiguration configuration, SecretClient secretClient)
     {
         private readonly ApplicationDbContext _context = context;
         private readonly ILogger<UsuarioService> _logger = logger;
         private readonly IConfiguration _configuration = configuration;
+        private readonly SecretClient _secretClient = secretClient;
 
         public async Task<Usuario> InserirAsync(CriacaoUsuarioRequest request)
         {
@@ -48,6 +50,33 @@ namespace BuscaMissa.Services.v1
             if(!SenhaHelper.Validar(request.Senha, usuario.Senha))
                 return false;
             return true;
+        }
+
+        // Retorna false quando a senha atual informada não confere (uso pelo próprio usuário).
+        public async Task<bool> TrocarSenhaAsync(Usuario usuario, string senhaAtual, string novaSenha)
+        {
+            if (!SenhaHelper.Validar(senhaAtual, usuario.Senha))
+                return false;
+
+            await AtualizarSenhaAsync(usuario, novaSenha);
+            return true;
+        }
+
+        // Reset administrativo: não exige a senha atual (uso restrito ao perfil Admin).
+        public async Task ResetarSenhaAsync(Usuario usuario, string novaSenha)
+        {
+            await AtualizarSenhaAsync(usuario, novaSenha);
+        }
+
+        private async Task AtualizarSenhaAsync(Usuario usuario, string novaSenha)
+        {
+            usuario.Senha = SenhaHelper.Encriptar(novaSenha);
+            await EditarAsync(usuario);
+
+            // A senha do Admin também vive como secret no Key Vault (fonte usada pelo
+            // DatabaseSeeder na primeira criação do usuário); mantém os dois sincronizados.
+            if (usuario.Email.Equals(Constants.Constants.EmailSuporte, StringComparison.OrdinalIgnoreCase))
+                await _secretClient.SetSecretAsync(Constants.Constants.SecretNameSenhaAdmin, novaSenha);
         }
 
         public async Task<Usuario?> BuscarPorCodigo(int id)
@@ -111,7 +140,8 @@ namespace BuscaMissa.Services.v1
                 AceitarPromocao = x.AceitarPromocao,
                 AceitarTermo = x.AceitarTermo,
                 Bloqueado = x.Bloqueado,
-                MotivoBloqueio = x.MotivoBloqueio
+                MotivoBloqueio = x.MotivoBloqueio,
+                TotalIgrejas = x.Igrejas.Count
             })
             .AsNoTracking()
             .AsQueryable();
@@ -122,11 +152,32 @@ namespace BuscaMissa.Services.v1
                 query = query.Where(x => x.Email.Contains(filtro.Email));
             if(filtro.Bloqueado.HasValue)
                 query = query.Where(x => x.Bloqueado == filtro.Bloqueado.Value);
+            if(filtro.Perfil.HasValue)
+                query = query.Where(x => x.Perfil == filtro.Perfil.Value);
+            if(filtro.CriacaoInicio.HasValue)
+                query = query.Where(x => x.Criacao >= filtro.CriacaoInicio.Value);
+            if(filtro.CriacaoFim.HasValue)
+                query = query.Where(x => x.Criacao <= filtro.CriacaoFim.Value);
 
             var resultado = await query.PaginacaoAsync(filtro.Paginacao.PageIndex, filtro.Paginacao.PageSize);
             return resultado;
         }
-    
+
+        public async Task<List<IgrejaResumoResponse>> BuscarIgrejasDoUsuarioAsync(int usuarioId)
+        {
+            return await _context.Igrejas
+                .Where(x => x.UsuarioId == usuarioId)
+                .Select(x => new IgrejaResumoResponse
+                {
+                    Id = x.Id,
+                    Nome = x.Nome,
+                    Uf = x.Endereco.Uf,
+                    Localidade = x.Endereco.Localidade
+                })
+                .AsNoTracking()
+                .ToListAsync();
+        }
+
     }
 }
 


### PR DESCRIPTION
## Summary
- Endpoint para o usuário trocar a própria senha (`PUT /Usuario/trocar-senha`) e para o Admin resetar a senha de qualquer usuário (`PUT /Admin/usuario/resetar-senha/{id}`); quando o alvo é o Admin, sincroniza também o secret `SenhaAdmin` no Key Vault via `SecretClient`
- Filtros adicionais na listagem de usuários: `Perfil`, `CriacaoInicio`, `CriacaoFim`
- Listagem de usuários agora retorna `TotalIgrejas` por usuário
- Novo endpoint `GET /Admin/usuario/{id}/igrejas` com nome/UF/cidade das igrejas cadastradas pelo usuário

## Test plan
- [x] Build local sem erros
- [x] Testado contra o banco real de dev (backend local): login, `trocar-senha` (senha atual errada → 400, correta → 200), `resetar-senha` (login com senha nova funciona), filtro por `Perfil`, `buscar-por-filtro` retornando `TotalIgrejas`, `usuario/{id}/igrejas` retornando lista correta