### PR TITLE
perf: bounding box em proximas-missas + cache de enderecos + teto de …

### DIFF
--- a/BuscaMissa/DTOs/v1/PaginacaoDto/PaginacaoRequest.cs
+++ b/BuscaMissa/DTOs/v1/PaginacaoDto/PaginacaoRequest.cs
@@ -4,10 +4,19 @@ namespace BuscaMissa.DTOs.PaginacaoDto
 {
     public class PaginacaoRequest
     {
+        /// <summary>Teto de itens por página imposto no servidor (nunca confiar no cliente) — 3.J.</summary>
+        public const int MaxPageSize = 50;
+
+        private int _pageSize = 10;
+
         [Required(ErrorMessage = "{0} é obrigatório!")]
         public int PageIndex { get; set; } = 1;
 
         [Required(ErrorMessage = "{0} é obrigatório!")]
-        public int PageSize { get; set; } = 10;
+        public int PageSize
+        {
+            get => _pageSize;
+            set => _pageSize = value < 1 ? 10 : (value > MaxPageSize ? MaxPageSize : value);
+        }
     }
 }

--- a/BuscaMissa/Program.cs
+++ b/BuscaMissa/Program.cs
@@ -61,6 +61,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     })
 );
 
+builder.Services.AddMemoryCache(); // cache de dados quentes (ex.: obter-enderecos) — 3.I
 builder.Services.AddHttpClient();
 builder.Services.AddHttpClient<ViaCepService>();
 builder.Services.AddHttpClient<BuscaMissa.Services.GeocodingService>();

--- a/BuscaMissa/Services/v1/EnderecoService.cs
+++ b/BuscaMissa/Services/v1/EnderecoService.cs
@@ -2,13 +2,20 @@ using BuscaMissa.Context;
 using BuscaMissa.DTOs.EnderecoDto;
 using BuscaMissa.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace BuscaMissa.Services.v1
 {
-    public class EnderecoService(ApplicationDbContext context, ILogger<EnderecoService> logger)
+    public class EnderecoService(ApplicationDbContext context, ILogger<EnderecoService> logger, IMemoryCache cache)
     {
         private readonly ApplicationDbContext _context = context;
         private readonly ILogger<EnderecoService> _logger = logger;
+        private readonly IMemoryCache _cache = cache;
+
+        // Dados de endereços mudam pouco (só ao cadastrar/editar igreja); TTL curto
+        // evita reagrupar toda a base a cada carregamento da home (3.I).
+        private const string CacheKeyOrganizarEnderecos = "enderecos:organizados";
+        private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(10);
 
         public async Task<Endereco> InserirAsync(EnderecoIgrejaRequest request)
         {
@@ -63,12 +70,16 @@ namespace BuscaMissa.Services.v1
         {
             try
             {
+            if (_cache.TryGetValue(CacheKeyOrganizarEnderecos,
+                    out Dictionary<string, Dictionary<string, List<string>>>? cached) && cached is not null)
+                return cached;
+
             var enderecos = await _context.Enderecos
                 .AsNoTracking()
                 .Where(x => x.Igreja.Ativo)
                 .ToListAsync();
 
-            return enderecos
+            var organizado = enderecos
                 .GroupBy(e => e.Uf)
                 .ToDictionary(
                 ufGroup => ufGroup.Key,
@@ -83,6 +94,9 @@ namespace BuscaMissa.Services.v1
                         .ToList()
                     )
                 );
+
+            _cache.Set(CacheKeyOrganizarEnderecos, organizado, CacheTtl);
+            return organizado;
             }
             catch (Exception ex)
             {

--- a/BuscaMissa/Services/v2/ProximasMissasService.cs
+++ b/BuscaMissa/Services/v2/ProximasMissasService.cs
@@ -47,6 +47,19 @@ public class ProximasMissasService(
             var janelaDe = agora;
             var janelaAte = agora.AddHours(request.Horas);
 
+            // Bounding box: pré-filtra no banco para ~centenas de igrejas dentro da
+            // caixa, em vez de trazer toda a base e calcular distância em C# (3.H).
+            // A caixa é um super-conjunto do círculo; o filtro de distância abaixo
+            // refina de caixa → círculo.
+            var latRad = lat * Math.PI / 180.0;
+            var deltaLat = raio / 111.0;
+            var cosLat = Math.Cos(latRad);
+            var deltaLng = Math.Abs(cosLat) < 1e-9 ? 180.0 : raio / (111.0 * Math.Abs(cosLat));
+            var minLat = (decimal)(lat - deltaLat);
+            var maxLat = (decimal)(lat + deltaLat);
+            var minLng = (decimal)(lng - deltaLng);
+            var maxLng = (decimal)(lng + deltaLng);
+
             var igrejas = await context.Igrejas
                 .Include(x => x.Endereco)
                 .Include(x => x.Missas)
@@ -54,7 +67,11 @@ public class ProximasMissasService(
                 .Where(x =>
                     x.Ativo &&
                     x.Endereco.Latitude != null &&
-                    x.Endereco.Longitude != null)
+                    x.Endereco.Longitude != null &&
+                    x.Endereco.Latitude >= minLat &&
+                    x.Endereco.Latitude <= maxLat &&
+                    x.Endereco.Longitude >= minLng &&
+                    x.Endereco.Longitude <= maxLng)
                 .ToListAsync();
 
             var resultado = new List<ProximaMissaDto>();


### PR DESCRIPTION
…pageSize (Etapa 3 - 3.H/3.I/3.J)

- 3.H: ProximasMissasService pre-filtra por bounding box no banco (Lat/Lng entre bounds derivados do raio) em vez de trazer toda a base; filtro de distancia em C# refina caixa->circulo
- 3.I: AddMemoryCache + cache (TTL 10min) de EnderecoService.OrganizarEnderecosAsync (agregacao pesada chamada em toda home)
- 3.J: PaginacaoRequest impoe MaxPageSize=50 no setter (server-side), cobrindo todos os filtros que compoem/herdam Paginacao