### PR TITLE
Auditoria e correção de indicadores + tela de Indicadores (backend)

### DIFF
--- a/BuscaMissa/Controllers/v1/AdminController.cs
+++ b/BuscaMissa/Controllers/v1/AdminController.cs
@@ -439,15 +439,17 @@ namespace BuscaMissa.Controllers.v1
             }
         }
 
+        // Etapa 8: endpoint único da tela de Indicadores (Cards + Rankings + Período + DataConsulta),
+        // evitando múltiplas chamadas do frontend.
         [HttpGet]
-        [Route("metricas/dashboard")]
+        [Route("indicadores")]
         [Authorize(Roles = "Admin")]
-        public async Task<ActionResult> ObterDashboardMetricas()
+        public async Task<ActionResult> ObterIndicadores([FromQuery] DateOnly? dataInicial, [FromQuery] DateOnly? dataFinal)
         {
             try
             {
-                var dashboard = await servicoConsultaMetricas.ObterDashboardAsync();
-                return Ok(new ApiResponse<dynamic>(dashboard));
+                var indicadores = await servicoConsultaMetricas.ObterIndicadoresAsync(dataInicial: dataInicial, dataFinal: dataFinal);
+                return Ok(new ApiResponse<dynamic>(indicadores));
             }
             catch (Exception ex)
             {

--- a/BuscaMissa/Controllers/v2/IgrejaController.cs
+++ b/BuscaMissa/Controllers/v2/IgrejaController.cs
@@ -160,6 +160,25 @@ namespace BuscaMissa.Controllers.v2
             _ => null
         };
 
+        // Backfill sob demanda de Slug/CidadeSlug para igrejas que nasceram sem esses campos
+        // (ex: criadas via CriarIgrejaAsync antes da correção, ou registros legados).
+        // Reaproveita a mesma rotina idempotente executada no startup, sem exigir restart do processo.
+        [HttpPost("backfill-slugs")]
+        [Authorize(Roles = "Admin")]
+        public IActionResult BackfillSlugs()
+        {
+            try
+            {
+                SlugBackfillService.Executar(dbContext);
+                return Ok(new ApiResponse<dynamic>(new { messagemAplicacao = "Backfill de slugs executado." }));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                return StatusCode(StatusCodes.Status500InternalServerError, new ApiResponse<dynamic>(BuscaMissa.Constants.Constants.MensagemErroInterno));
+            }
+        }
+
         // Endpoint admin: busca completa por Id, sem filtrar por Ativo (uso no painel administrativo)
         [HttpGet("admin/{id:int}")]
         [Authorize(Roles = "Admin")]

--- a/BuscaMissa/DTOs/MetricasDto/IndicadoresResponse.cs
+++ b/BuscaMissa/DTOs/MetricasDto/IndicadoresResponse.cs
@@ -1,0 +1,8 @@
+namespace BuscaMissa.DTOs.MetricasDto;
+
+// Payload único da tela de Indicadores (Etapa 8): evita múltiplas chamadas do frontend.
+public record IndicadoresResponse(
+    TotaisSistemaResponse Cards,
+    RankingsResponse Rankings,
+    PeriodoResponse Periodo,
+    DateTime DataConsulta);

--- a/BuscaMissa/DTOs/MetricasDto/PeriodoResponse.cs
+++ b/BuscaMissa/DTOs/MetricasDto/PeriodoResponse.cs
@@ -1,0 +1,3 @@
+namespace BuscaMissa.DTOs.MetricasDto;
+
+public record PeriodoResponse(DateOnly? DataInicial, DateOnly? DataFinal);

--- a/BuscaMissa/DTOs/MetricasDto/RankingIgrejaResponse.cs
+++ b/BuscaMissa/DTOs/MetricasDto/RankingIgrejaResponse.cs
@@ -1,3 +1,3 @@
 namespace BuscaMissa.DTOs.MetricasDto;
 
-public record RankingIgrejaResponse(int IgrejaId, string Nome, int Quantidade);
+public record RankingIgrejaResponse(int IgrejaId, string Nome, string Cidade, string Uf, int Quantidade);

--- a/BuscaMissa/DTOs/MetricasDto/RankingsResponse.cs
+++ b/BuscaMissa/DTOs/MetricasDto/RankingsResponse.cs
@@ -1,7 +1,6 @@
 namespace BuscaMissa.DTOs.MetricasDto;
 
-public record DashboardMetricasResponse(
-    TotaisSistemaResponse Totais,
+public record RankingsResponse(
     IList<RankingIgrejaResponse> MaisVisualizadas,
     IList<RankingIgrejaResponse> MaisFavoritadas,
     IList<RankingIgrejaResponse> MaisCompartilhadas,

--- a/BuscaMissa/Services/ServicoConsultaMetricas.cs
+++ b/BuscaMissa/Services/ServicoConsultaMetricas.cs
@@ -48,31 +48,41 @@ public class ServicoConsultaMetricas(ApplicationDbContext context)
         return rows.Select(x => new MetricaResumoResponse(x.TipoMetrica, x.Quantidade)).ToList();
     }
 
-    public async Task<IList<RankingItemResponse>> ObterRankingMaisVisualizadasAsync(int top = 10, int dias = 30)
-        => await ObterRankingAsync(TipoMetricaEnum.VisualizacaoIgreja, top, dias);
+    public async Task<IList<RankingItemResponse>> ObterRankingMaisVisualizadasAsync(
+        int top = 10, DateOnly? dataInicio = null, DateOnly? dataFim = null)
+        => await ObterRankingAsync(TipoMetricaEnum.VisualizacaoIgreja, top, dataInicio, dataFim);
 
-    public async Task<IList<RankingItemResponse>> ObterRankingMaisFavoritadasAsync(int top = 10, int dias = 30)
-        => await ObterRankingAsync(TipoMetricaEnum.Favorito, top, dias);
+    public async Task<IList<RankingItemResponse>> ObterRankingMaisFavoritadasAsync(
+        int top = 10, DateOnly? dataInicio = null, DateOnly? dataFim = null)
+        => await ObterRankingAsync(TipoMetricaEnum.Favorito, top, dataInicio, dataFim);
 
-    public async Task<IList<RankingItemResponse>> ObterRankingMaisCompartilhadasAsync(int top = 10, int dias = 30)
-        => await ObterRankingAsync(TipoMetricaEnum.Compartilhamento, top, dias);
+    public async Task<IList<RankingItemResponse>> ObterRankingMaisCompartilhadasAsync(
+        int top = 10, DateOnly? dataInicio = null, DateOnly? dataFim = null)
+        => await ObterRankingAsync(TipoMetricaEnum.Compartilhamento, top, dataInicio, dataFim);
 
-    public async Task<IList<RankingItemResponse>> ObterRankingMaisRotasAbertasAsync(int top = 10, int dias = 30)
-        => await ObterRankingAsync(TipoMetricaEnum.CliqueRota, top, dias);
+    public async Task<IList<RankingItemResponse>> ObterRankingMaisRotasAbertasAsync(
+        int top = 10, DateOnly? dataInicio = null, DateOnly? dataFim = null)
+        => await ObterRankingAsync(TipoMetricaEnum.CliqueRota, top, dataInicio, dataFim);
 
+    // Sem DataInicial/DataFinal informados, considera todo o histórico (sem filtro de data).
     private async Task<IList<RankingItemResponse>> ObterRankingAsync(
-        TipoMetricaEnum tipoMetrica, int top, int dias)
+        TipoMetricaEnum tipoMetrica, int top, DateOnly? dataInicio, DateOnly? dataFim)
     {
-        var dataInicio = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-dias);
-
-        // Projeção com tipo anônimo para compatibilidade com EF Core/MySQL:
-        // records com construtor parametrizado não são suportados na tradução SQL.
-        var rows = await context.MetricasDiarias
+        var query = context.MetricasDiarias
             .AsNoTracking()
             .Where(x =>
                 x.TipoEntidade == TipoEntidadeMetricaEnum.Igreja &&
-                x.TipoMetrica == tipoMetrica &&
-                x.Data >= dataInicio)
+                x.TipoMetrica == tipoMetrica);
+
+        if (dataInicio is not null)
+            query = query.Where(x => x.Data >= dataInicio);
+
+        if (dataFim is not null)
+            query = query.Where(x => x.Data <= dataFim);
+
+        // Projeção com tipo anônimo para compatibilidade com EF Core/MySQL:
+        // records com construtor parametrizado não são suportados na tradução SQL.
+        var rows = await query
             .GroupBy(x => x.EntidadeId)
             .Select(g => new { EntidadeId = g.Key, Quantidade = g.Sum(x => x.Quantidade) })
             .OrderByDescending(x => x.Quantidade)
@@ -82,32 +92,51 @@ public class ServicoConsultaMetricas(ApplicationDbContext context)
         return rows.Select(x => new RankingItemResponse(x.EntidadeId, x.Quantidade)).ToList();
     }
 
-    /// <summary>Resolve o ranking (Id + Quantidade) para o formato exibível no dashboard, com o nome da igreja.</summary>
+    /// <summary>Resolve o ranking (Id + Quantidade) para o formato exibível no dashboard, com nome/cidade/UF da igreja.</summary>
     private async Task<IList<RankingIgrejaResponse>> ObterRankingIgrejasAsync(
-        TipoMetricaEnum tipoMetrica, int top, int dias)
+        TipoMetricaEnum tipoMetrica, int top, DateOnly? dataInicio, DateOnly? dataFim)
     {
-        var ranking = await ObterRankingAsync(tipoMetrica, top, dias);
+        var ranking = await ObterRankingAsync(tipoMetrica, top, dataInicio, dataFim);
         if (ranking.Count == 0) return new List<RankingIgrejaResponse>();
 
         var ids = ranking.Select(x => x.EntidadeId).ToList();
-        var nomes = await context.Igrejas
+        var igrejas = await context.Igrejas
+            .Include(x => x.Endereco)
             .AsNoTracking()
             .Where(x => ids.Contains(x.Id))
-            .ToDictionaryAsync(x => x.Id, x => x.Nome);
+            .ToDictionaryAsync(x => x.Id, x => new { x.Nome, Cidade = x.Endereco.Localidade, x.Endereco.Uf });
 
+        // Ordenação: quantidade decrescente; em empate, por nome (regra da Etapa 2).
         return ranking
-            .Select(x => new RankingIgrejaResponse(x.EntidadeId, nomes.GetValueOrDefault(x.EntidadeId, "—"), x.Quantidade))
+            .Select(x =>
+            {
+                var dados = igrejas.GetValueOrDefault(x.EntidadeId);
+                return new RankingIgrejaResponse(
+                    x.EntidadeId,
+                    dados?.Nome ?? "—",
+                    dados?.Cidade ?? "—",
+                    dados?.Uf ?? "—",
+                    x.Quantidade);
+            })
+            .OrderByDescending(x => x.Quantidade)
+            .ThenBy(x => x.Nome)
             .ToList();
     }
 
-    /// <summary>Totais gerais do sistema (todas as igrejas) nos últimos 30 dias.</summary>
-    public async Task<TotaisSistemaResponse> ObterTotaisSistemaUltimos30DiasAsync()
+    /// <summary>Totais gerais do sistema (todas as igrejas). Sem datas informadas, considera todo o histórico.</summary>
+    public async Task<TotaisSistemaResponse> ObterTotaisSistemaAsync(DateOnly? dataInicio = null, DateOnly? dataFim = null)
     {
-        var dataInicio = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30);
-
-        var totais = await context.MetricasDiarias
+        var query = context.MetricasDiarias
             .AsNoTracking()
-            .Where(x => x.TipoEntidade == TipoEntidadeMetricaEnum.Igreja && x.Data >= dataInicio)
+            .Where(x => x.TipoEntidade == TipoEntidadeMetricaEnum.Igreja);
+
+        if (dataInicio is not null)
+            query = query.Where(x => x.Data >= dataInicio);
+
+        if (dataFim is not null)
+            query = query.Where(x => x.Data <= dataFim);
+
+        var totais = await query
             .GroupBy(x => x.TipoMetrica)
             .Select(g => new { Tipo = g.Key, Total = g.Sum(x => x.Quantidade) })
             .ToListAsync();
@@ -120,16 +149,23 @@ public class ServicoConsultaMetricas(ApplicationDbContext context)
             Obter(TipoMetricaEnum.Compartilhamento));
     }
 
-    /// <summary>Dados completos da tela de Indicadores: totais do sistema + 4 rankings de igrejas.</summary>
-    public async Task<DashboardMetricasResponse> ObterDashboardAsync(int top = 10, int dias = 30)
+    /// <summary>
+    /// Payload único da tela de Indicadores (Cards + Rankings + Período + DataConsulta) — Etapa 8:
+    /// substitui múltiplas chamadas por uma única consulta ao backend.
+    /// DataInicial/DataFinal são opcionais — se ausentes, considera todo o histórico (Etapa 1).
+    /// </summary>
+    public async Task<IndicadoresResponse> ObterIndicadoresAsync(
+        int top = 10, DateOnly? dataInicial = null, DateOnly? dataFinal = null)
     {
-        var totais = await ObterTotaisSistemaUltimos30DiasAsync();
-        var maisVisualizadas = await ObterRankingIgrejasAsync(TipoMetricaEnum.VisualizacaoIgreja, top, dias);
-        var maisFavoritadas = await ObterRankingIgrejasAsync(TipoMetricaEnum.Favorito, top, dias);
-        var maisCompartilhadas = await ObterRankingIgrejasAsync(TipoMetricaEnum.Compartilhamento, top, dias);
-        var maisRotasAbertas = await ObterRankingIgrejasAsync(TipoMetricaEnum.CliqueRota, top, dias);
+        var cards = await ObterTotaisSistemaAsync(dataInicial, dataFinal);
+        var maisVisualizadas = await ObterRankingIgrejasAsync(TipoMetricaEnum.VisualizacaoIgreja, top, dataInicial, dataFinal);
+        var maisFavoritadas = await ObterRankingIgrejasAsync(TipoMetricaEnum.Favorito, top, dataInicial, dataFinal);
+        var maisCompartilhadas = await ObterRankingIgrejasAsync(TipoMetricaEnum.Compartilhamento, top, dataInicial, dataFinal);
+        var maisRotasAbertas = await ObterRankingIgrejasAsync(TipoMetricaEnum.CliqueRota, top, dataInicial, dataFinal);
 
-        return new DashboardMetricasResponse(
-            totais, maisVisualizadas, maisFavoritadas, maisCompartilhadas, maisRotasAbertas);
+        var rankings = new RankingsResponse(maisVisualizadas, maisFavoritadas, maisCompartilhadas, maisRotasAbertas);
+        var periodo = new PeriodoResponse(dataInicial, dataFinal);
+
+        return new IndicadoresResponse(cards, rankings, periodo, DateTime.UtcNow);
     }
 }

--- a/BuscaMissa/Services/v2/IgrejaService.cs
+++ b/BuscaMissa/Services/v2/IgrejaService.cs
@@ -44,6 +44,23 @@ public class IgrejaService(
         try
         {
             Igreja model = (Igreja)request;
+
+            // CidadeSlug (desnormalizado para URLs e busca por cidade)
+            model.Endereco.CidadeSlug = IgrejaHelper.CriarCidadeSlug(model.Endereco.Localidade);
+
+            model.NomeUnico = await GerarSlugUnicoAsync(
+                IgrejaHelper.CriarNomeUnico(model),
+                model.Endereco.Bairro,
+                model.Endereco.Logradouro);
+
+            // Slug local à cidade, único dentro de (Uf, CidadeSlug)
+            model.Slug = await GerarSlugLocalUnicoAsync(
+                IgrejaHelper.CriarSlugLocal(model.Nome),
+                model.Endereco.Bairro,
+                model.Endereco.Logradouro,
+                model.Endereco.Uf,
+                model.Endereco.CidadeSlug);
+
             context.Igrejas.Add(model);
             await context.SaveChangesAsync();
 
@@ -59,6 +76,26 @@ public class IgrejaService(
             logger.LogError(ex, "An error occurred while insering Igreja {IgrejaRequest}", request);
             throw;
         }
+    }
+
+    // NomeUnico global: desempata homônimas por bairro/logradouro (sem sufixo numérico)
+    private async Task<string> GerarSlugUnicoAsync(string baseSlug, string? bairro, string? logradouro)
+    {
+        foreach (var cand in IgrejaHelper.CandidatosSlug(baseSlug, bairro, logradouro))
+            if (!await context.Igrejas.AnyAsync(x => x.NomeUnico == cand))
+                return cand;
+        return $"{baseSlug}-{Guid.NewGuid().ToString("N")[..6]}";
+    }
+
+    // Slug local à cidade (Uf + CidadeSlug): mesma escalada por bairro/logradouro
+    private async Task<string> GerarSlugLocalUnicoAsync(string baseSlug, string? bairro, string? logradouro,
+        string uf, string cidadeSlug)
+    {
+        foreach (var cand in IgrejaHelper.CandidatosSlug(baseSlug, bairro, logradouro))
+            if (!await context.Igrejas.AnyAsync(x =>
+                    x.Slug == cand && x.Endereco.Uf == uf && x.Endereco.CidadeSlug == cidadeSlug))
+                return cand;
+        return $"{baseSlug}-{Guid.NewGuid().ToString("N")[..6]}";
     }
     
     public async Task<IList<Igreja>> BuscarPorCepAsync(string cep)


### PR DESCRIPTION
## Resumo
- Corrige causa raiz de visualizações não contabilizadas: igrejas criadas via `POST /api/v2/Igreja` nasciam sem `Slug`/`NomeUnico`, quebrando os links `/paroquia/...` e impedindo a página de detalhes de carregar (e, portanto, o evento de visualização de disparar).
- Adiciona endpoint de backfill sob demanda (`POST /api/v2/Igreja/backfill-slugs`) para sanar registros legados sem depender de restart do processo.
- Consolida os indicadores em um único endpoint `GET /api/v1/admin/indicadores`, substituindo `metricas/dashboard`:
  - Aceita `DataInicial`/`DataFinal` opcionais (sem filtro = todo o histórico).
  - Retorna `{ cards, rankings, periodo, dataConsulta }`.
  - Rankings trazem Cidade/UF de cada igreja, ordenados por quantidade e desempate por nome.
- Agregações continuam feitas no banco (`GROUP BY`/`SUM`/`TOP N` traduzidos pelo EF Core), sem carregar tabelas inteiras em memória.

## Test plan
- [x] `dotnet build` sem erros novos
- [ ] Testar localmente end-to-end com o frontend admin atualizado (PR companheiro)