### PR TITLE
fix: corrige fuso horário na agregação diária de métricas

### DIFF
--- a/BuscaMissa/Helpers/DataHoraHelper.cs
+++ b/BuscaMissa/Helpers/DataHoraHelper.cs
@@ -4,6 +4,31 @@ namespace BuscaMissa.Helpers
 {
     public static class DataHoraHelper
     {
+        // Fuso horário padrão do Brasil — Windows e Linux têm IDs diferentes.
+        // Brasil não observa mais horário de verão (desde 2019), então é fixo em UTC-3.
+        public static readonly TimeZoneInfo FusoBrasilia = CarregarFusoBrasilia();
+
+        private static TimeZoneInfo CarregarFusoBrasilia()
+        {
+            foreach (var id in new[] { "E. South America Standard Time", "America/Sao_Paulo" })
+            {
+                try { return TimeZoneInfo.FindSystemTimeZoneById(id); }
+                catch { /* tenta o próximo */ }
+            }
+            return TimeZoneInfo.Utc; // fallback improvável — UTC-0 melhor do que exceção
+        }
+
+        /// <summary>Hora atual no fuso do Brasil, a partir de DateTime.UtcNow.</summary>
+        public static DateTime AgoraBrasil() => TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, FusoBrasilia);
+
+        /// <summary>
+        /// Dia de hoje no fuso do Brasil. Usar sempre que "hoje" for atribuído a um
+        /// registro (ex: agregação diária de métricas) — DateOnly.FromDateTime(DateTime.UtcNow)
+        /// vira o dia ~3h antes da meia-noite real no Brasil (ex: 21h de domingo já é
+        /// segunda em UTC).
+        /// </summary>
+        public static DateOnly HojeBrasil() => DateOnly.FromDateTime(AgoraBrasil());
+
         public static string Formatar(DateTime dateTime)
         {
             return dateTime.ToString("dd/MM/yyyy HH:mm");

--- a/BuscaMissa/Scripts/fix_timezone_metricas_diarias.sql
+++ b/BuscaMissa/Scripts/fix_timezone_metricas_diarias.sql
@@ -1,0 +1,103 @@
+-- =============================================================
+-- SCRIPT: Correção retroativa de MetricasDiarias.Data (bug de fuso horário)
+-- Contexto: ServicoMetricas.IncrementarAsync calculava o "dia de hoje"
+-- com DateOnly.FromDateTime(DateTime.UtcNow). Como o Brasil é UTC-3,
+-- toda métrica registrada entre 21:00 e 23:59 (horário do Brasil) foi
+-- gravada com Data = dia seguinte (pois em UTC já era 00:00-02:59 do
+-- dia seguinte). Corrigido em fix/timezone-metricas-brasil (PR #90).
+--
+-- LIMITAÇÃO IMPORTANTE: MetricasDiarias guarda só a contagem agregada
+-- por dia (Quantidade), não o horário de cada incremento individual.
+-- Só sabemos o instante do PRIMEIRO incremento do dia (CriadoEm) e do
+-- ÚLTIMO (AtualizadoEm). Por isso, só corrigimos automaticamente as
+-- linhas em que TODA a atividade do dia (criação e última atualização)
+-- ficou dentro da janela suspeita — ou seja, não há risco de mover
+-- incrementos que legitimamente pertencem ao dia certo.
+-- Linhas com atividade "misturada" (começaram na janela suspeita mas
+-- continuaram depois) ficam listadas para revisão manual (Passo 2) e
+-- NÃO são alteradas por este script.
+--
+-- FAÇA BACKUP da tabela MetricasDiarias antes de rodar os passos 3 e 4.
+-- Banco: BuscaMissa (DEV ou PROD)
+-- =============================================================
+
+-- PASSO 1: Diagnóstico — dimensiona o problema antes de mexer
+-- -------------------------------------------------------
+SELECT
+    COUNT(*) AS total_linhas,
+    SUM(HOUR(CriadoEm) IN (0, 1, 2) AND DATE(CriadoEm) = Data) AS linhas_com_criacao_suspeita,
+    SUM(
+        HOUR(CriadoEm) IN (0, 1, 2) AND DATE(CriadoEm) = Data
+        AND HOUR(AtualizadoEm) IN (0, 1, 2) AND DATE(AtualizadoEm) = Data
+    ) AS linhas_seguras_para_corrigir,
+    SUM(
+        HOUR(CriadoEm) IN (0, 1, 2) AND DATE(CriadoEm) = Data
+        AND NOT (HOUR(AtualizadoEm) IN (0, 1, 2) AND DATE(AtualizadoEm) = Data)
+    ) AS linhas_mistas_revisao_manual
+FROM MetricasDiarias;
+
+-- PASSO 2: Linhas "mistas" — atividade começou na janela suspeita mas
+-- continuou depois das 03:00 UTC (00:00 Brasil). Não são alteradas
+-- automaticamente porque não dá para saber quantos dos incrementos
+-- pertencem ao dia certo e quantos ao dia anterior. Revise manualmente
+-- se o volume for relevante.
+-- -------------------------------------------------------
+SELECT
+    Id, TipoEntidade, EntidadeId, TipoMetrica, Data, Quantidade, CriadoEm, AtualizadoEm
+FROM MetricasDiarias
+WHERE HOUR(CriadoEm) IN (0, 1, 2) AND DATE(CriadoEm) = Data
+  AND NOT (HOUR(AtualizadoEm) IN (0, 1, 2) AND DATE(AtualizadoEm) = Data)
+ORDER BY Data, EntidadeId;
+
+-- PASSO 3: Corrige linhas seguras SEM conflito — quando ainda não existe
+-- uma linha para (TipoEntidade, EntidadeId, TipoMetrica, Data - 1), basta
+-- mover a própria linha um dia para trás.
+-- -------------------------------------------------------
+UPDATE MetricasDiarias m
+SET Data = DATE_SUB(Data, INTERVAL 1 DAY)
+WHERE HOUR(m.CriadoEm) IN (0, 1, 2) AND DATE(m.CriadoEm) = m.Data
+  AND HOUR(m.AtualizadoEm) IN (0, 1, 2) AND DATE(m.AtualizadoEm) = m.Data
+  AND NOT EXISTS (
+      SELECT 1 FROM MetricasDiarias m2
+      WHERE m2.TipoEntidade = m.TipoEntidade
+        AND m2.EntidadeId   = m.EntidadeId
+        AND m2.TipoMetrica  = m.TipoMetrica
+        AND m2.Data         = DATE_SUB(m.Data, INTERVAL 1 DAY)
+  );
+
+-- PASSO 4: Corrige linhas seguras COM conflito — já existe uma linha
+-- legítima para o dia anterior (mesma entidade/tipo de métrica). Soma a
+-- quantidade nela, estende CriadoEm/AtualizadoEm e remove a linha errada.
+-- -------------------------------------------------------
+UPDATE MetricasDiarias destino
+JOIN MetricasDiarias origem
+  ON  destino.TipoEntidade = origem.TipoEntidade
+  AND destino.EntidadeId   = origem.EntidadeId
+  AND destino.TipoMetrica  = origem.TipoMetrica
+  AND destino.Data         = DATE_SUB(origem.Data, INTERVAL 1 DAY)
+SET
+  destino.Quantidade   = destino.Quantidade + origem.Quantidade,
+  destino.CriadoEm     = LEAST(destino.CriadoEm, origem.CriadoEm),
+  destino.AtualizadoEm = GREATEST(destino.AtualizadoEm, origem.AtualizadoEm)
+WHERE HOUR(origem.CriadoEm) IN (0, 1, 2) AND DATE(origem.CriadoEm) = origem.Data
+  AND HOUR(origem.AtualizadoEm) IN (0, 1, 2) AND DATE(origem.AtualizadoEm) = origem.Data;
+
+DELETE origem FROM MetricasDiarias origem
+JOIN MetricasDiarias destino
+  ON  destino.TipoEntidade = origem.TipoEntidade
+  AND destino.EntidadeId   = origem.EntidadeId
+  AND destino.TipoMetrica  = origem.TipoMetrica
+  AND destino.Data         = DATE_SUB(origem.Data, INTERVAL 1 DAY)
+WHERE HOUR(origem.CriadoEm) IN (0, 1, 2) AND DATE(origem.CriadoEm) = origem.Data
+  AND HOUR(origem.AtualizadoEm) IN (0, 1, 2) AND DATE(origem.AtualizadoEm) = origem.Data;
+
+-- PASSO 5: Verificação final — deve restar só as linhas "mistas" do
+-- Passo 2 (se houver), já que essas não são tocadas por este script.
+-- -------------------------------------------------------
+SELECT
+    COUNT(*) AS total_linhas,
+    SUM(
+        HOUR(CriadoEm) IN (0, 1, 2) AND DATE(CriadoEm) = Data
+        AND HOUR(AtualizadoEm) IN (0, 1, 2) AND DATE(AtualizadoEm) = Data
+    ) AS linhas_seguras_restantes -- deve ser 0 após rodar os passos 3 e 4
+FROM MetricasDiarias;

--- a/BuscaMissa/Services/ServicoConsultaMetricas.cs
+++ b/BuscaMissa/Services/ServicoConsultaMetricas.cs
@@ -1,6 +1,7 @@
 using BuscaMissa.Context;
 using BuscaMissa.DTOs.MetricasDto;
 using BuscaMissa.Enums;
+using BuscaMissa.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace BuscaMissa.Services;
@@ -33,7 +34,7 @@ public class ServicoConsultaMetricas(ApplicationDbContext context)
     public async Task<IList<MetricaResumoResponse>> ObterMetricasUltimos30DiasAsync(
         TipoEntidadeMetricaEnum tipoEntidade, int entidadeId)
     {
-        var dataInicio = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30);
+        var dataInicio = DataHoraHelper.HojeBrasil().AddDays(-30);
 
         var rows = await context.MetricasDiarias
             .AsNoTracking()

--- a/BuscaMissa/Services/ServicoMetricas.cs
+++ b/BuscaMissa/Services/ServicoMetricas.cs
@@ -1,4 +1,5 @@
 using BuscaMissa.Enums;
+using BuscaMissa.Helpers;
 using BuscaMissa.Models;
 using BuscaMissa.Repositorios;
 
@@ -15,7 +16,7 @@ public class ServicoMetricas(
     {
         try
         {
-            var hoje = DateOnly.FromDateTime(DateTime.UtcNow);
+            var hoje = DataHoraHelper.HojeBrasil();
 
             var metrica = await repositorio.ObterAsync(tipoEntidade, entidadeId, tipoMetrica, hoje);
 

--- a/BuscaMissa/Services/v2/ProximasMissasService.cs
+++ b/BuscaMissa/Services/v2/ProximasMissasService.cs
@@ -13,19 +13,6 @@ public class ProximasMissasService(
     ImagemService imagemService,
     ILogger<ProximasMissasService> logger)
 {
-    // Fuso horário padrão do Brasil — Windows e Linux têm IDs diferentes
-    private static readonly TimeZoneInfo FusoBrasilia = CarregarFusoBrasilia();
-
-    private static TimeZoneInfo CarregarFusoBrasilia()
-    {
-        foreach (var id in new[] { "E. South America Standard Time", "America/Sao_Paulo" })
-        {
-            try { return TimeZoneInfo.FindSystemTimeZoneById(id); }
-            catch { /* tenta o próximo */ }
-        }
-        return TimeZoneInfo.Utc; // fallback improvável — UTC-0 melhor do que exceção
-    }
-
     // Coords SP metro usadas quando usuário não fornece localização
     private const double FallbackLat = -23.5505;
     private const double FallbackLng = -46.6333;
@@ -43,7 +30,7 @@ public class ProximasMissasService(
 
         try
         {
-            var agora = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, FusoBrasilia);
+            var agora = DataHoraHelper.AgoraBrasil();
             var janelaDe = agora;
             var janelaAte = agora.AddHours(request.Horas);
 


### PR DESCRIPTION
## Problema
Em produção, no domingo 05/07/2026 às 21h (horário do Brasil), os indicadores já estavam contabilizando a métrica como se fosse segunda-feira 06/07.

## Causa raiz
`ServicoMetricas.IncrementarAsync` calculava o "dia de hoje" (usado para agrupar `MetricaDiaria.Data`) com `DateOnly.FromDateTime(DateTime.UtcNow)`. Como o Brasil está em UTC-3 (sem horário de verão desde 2019), a partir das 21h local o horário em UTC já é meia-noite do dia seguinte — virando o dia errado nas métricas diárias, no filtro "Hoje"/"Ontem"/"Mês corrente" e nos rankings por período.

## Correção
- Centraliza o fuso do Brasil em `DataHoraHelper` (`FusoBrasilia`, `AgoraBrasil()`, `HojeBrasil()`), reaproveitando a lógica que já existia isolada em `ProximasMissasService` (troca de `TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, FusoBrasilia)` local por chamada ao helper compartilhado).
- `ServicoMetricas.IncrementarAsync` passa a usar `DataHoraHelper.HojeBrasil()` para decidir a que dia a métrica pertence.
- `ServicoConsultaMetricas.ObterMetricasUltimos30DiasAsync` também corrigido (mesma classe de bug no cálculo do início da janela de 30 dias).

## Test plan
- [x] `dotnet build` sem erros novos
- [ ] Validar em produção que, próximo às 21h-00h do horário do Brasil, novas visualizações/favoritos/compartilhamentos continuam sendo contados no dia correto