### PR TITLE
fix: slug estável nas edições e filtro de e-mail vazio na Divulgação

### DIFF
--- a/BuscaMissa/Services/v1/DivulgacaoService.cs
+++ b/BuscaMissa/Services/v1/DivulgacaoService.cs
@@ -100,13 +100,13 @@ public class DivulgacaoService(
         return modo switch
         {
             ModoDivulgacaoEnum.SemContatoEmail => query
-                .Where(x => x.Contato != null && x.Contato.EmailContato != null)
+                .Where(x => x.Contato != null && !string.IsNullOrWhiteSpace(x.Contato.EmailContato))
                 .Where(x => !context.EmailEventosIgreja.Any(e =>
                     e.IgrejaId == x.Id && e.Canal == CanalContatoEnum.Email && e.Enviado)),
 
             ModoDivulgacaoEnum.SemEmailAlteracaoPendente => query
                 .Where(x => x.Alteracao > x.Criacao)
-                .Where(x => x.Contato != null && x.Contato.EmailContato != null)
+                .Where(x => x.Contato != null && !string.IsNullOrWhiteSpace(x.Contato.EmailContato))
                 .Where(x => !context.EmailEventosIgreja.Any(e =>
                     e.IgrejaId == x.Id &&
                     e.Tipo == TipoEmailEventoIgrejaEnum.Alteracao &&

--- a/BuscaMissa/Services/v1/IgrejaService.cs
+++ b/BuscaMissa/Services/v1/IgrejaService.cs
@@ -721,19 +721,28 @@ namespace BuscaMissa.Services.v1
                     model.Endereco.CidadeSlug = IgrejaHelper.CriarCidadeSlug(model.Endereco.Localidade);
                 }
 
-                model.NomeUnico = await GerarSlugUnicoAsync(
-                    IgrejaHelper.CriarNomeUnico(model),
-                    model.Endereco.Bairro,
-                    model.Endereco.Logradouro,
-                    model.Id);
+                // NomeUnico/Slug só são gerados uma vez (na criação ou no backfill). Regenerar a cada
+                // edição quebraria links já compartilhados/enviados por e-mail sempre que o nome da
+                // igreja mudasse (ex: correção de digitação passava a apontar para uma URL diferente).
+                if (string.IsNullOrWhiteSpace(model.NomeUnico))
+                {
+                    model.NomeUnico = await GerarSlugUnicoAsync(
+                        IgrejaHelper.CriarNomeUnico(model),
+                        model.Endereco.Bairro,
+                        model.Endereco.Logradouro,
+                        model.Id);
+                }
 
-                model.Slug = await GerarSlugLocalUnicoAsync(
-                    IgrejaHelper.CriarSlugLocal(model.Nome),
-                    model.Endereco.Bairro,
-                    model.Endereco.Logradouro,
-                    model.Endereco.Uf,
-                    model.Endereco.CidadeSlug,
-                    model.Id);
+                if (string.IsNullOrWhiteSpace(model.Slug))
+                {
+                    model.Slug = await GerarSlugLocalUnicoAsync(
+                        IgrejaHelper.CriarSlugLocal(model.Nome),
+                        model.Endereco.Bairro,
+                        model.Endereco.Logradouro,
+                        model.Endereco.Uf,
+                        model.Endereco.CidadeSlug,
+                        model.Id);
+                }
 
                 var listExcluir = model.Missas.Where(x => !request.Missas.Any(y => y.Id == x.Id)).ToList();
                 await RemoverMissaAsync(listExcluir);


### PR DESCRIPTION
## Resumo
Dois ajustes pedidos junto com melhorias no admin (ver PR companheiro no frontend):

1. **`IgrejaService.EditarAsync`**: `NomeUnico`/`Slug` eram recalculados a partir do nome atual em TODA edição, mesmo quando o nome não mudava de forma significativa. Isso quebrava qualquer link já compartilhado/enviado por e-mail sempre que o nome da igreja era ajustado (ex: correção de digitação). Agora só são gerados quando ainda estão vazios (nunca gerados antes), preservando a URL pública estável entre edições.

2. **`DivulgacaoService.AplicarModo`** (modos `SemContatoEmail` e `SemEmailAlteracaoPendente`): o filtro checava `x.Contato.EmailContato != null`, mas igrejas sem e-mail cadastrado ficam com **string vazia**, não `null` — passavam pelo filtro incorretamente, aparecendo como "sem contato via e-mail" mesmo sem ter e-mail nenhum pra contatar. Trocado para `!string.IsNullOrWhiteSpace(...)`.

## Test plan
- [x] `dotnet build` sem erros novos
- [ ] Teste manual: editar uma igreja mudando só o nome e confirmar que o slug/URL não muda
- [ ] Teste manual: conferir que o filtro "Sem contato via e-mail" não lista mais igrejas sem e-mail cadastrado