### PR TITLE
feat: fila de aprovações pendentes (Controle) para o Admin

### DIFF
--- a/BuscaMissa/Controllers/v1/AprovacaoController.cs
+++ b/BuscaMissa/Controllers/v1/AprovacaoController.cs
@@ -1,0 +1,103 @@
+using BuscaMissa.DTOs;
+using BuscaMissa.DTOs.ControleDto;
+using BuscaMissa.Services.v1;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BuscaMissa.Controllers.v1
+{
+    // Fila de Aprovações Pendentes (Admin): visão sobre Controle/IgrejaTemporaria/MissaTemporaria
+    // já existentes, sem nenhuma tabela de log nova.
+    [ApiController]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize(Roles = "Admin")]
+    public class AprovacaoController(ILogger<AprovacaoController> logger, AprovacaoService aprovacaoService)
+    : ControllerBase
+    {
+        [HttpGet]
+        [Route("pendentes")]
+        public async Task<IActionResult> BuscarPendentes([FromQuery] FiltroControleRequest filtro)
+        {
+            try
+            {
+                var resultado = await aprovacaoService.BuscarPendentesAsync(filtro);
+                return Ok(new ApiResponse<dynamic>(resultado));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                return StatusCode(StatusCodes.Status500InternalServerError, new ApiResponse<dynamic>(BuscaMissa.Constants.Constants.MensagemErroInterno));
+            }
+        }
+
+        [HttpGet]
+        [Route("{controleId}/detalhe")]
+        public async Task<IActionResult> ObterDetalhe(int controleId)
+        {
+            try
+            {
+                var detalhe = await aprovacaoService.ObterDetalheAsync(controleId);
+                if (detalhe is null) return NotFound(new ApiResponse<dynamic>(new { mensagemAplicacao = "Controle não encontrado." }));
+                return Ok(new ApiResponse<dynamic>(detalhe));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                return StatusCode(StatusCodes.Status500InternalServerError, new ApiResponse<dynamic>(BuscaMissa.Constants.Constants.MensagemErroInterno));
+            }
+        }
+
+        [HttpPost]
+        [Route("{controleId}/aprovar")]
+        public async Task<IActionResult> Aprovar(int controleId)
+        {
+            try
+            {
+                var sucesso = await aprovacaoService.AprovarAsync(controleId);
+                if (!sucesso) return BadRequest(new ApiResponse<dynamic>(new { mensagemAplicacao = "Não foi possível aprovar este item." }));
+                return Ok(new ApiResponse<dynamic>(new { mensagemAplicacao = "Aprovado com sucesso." }));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                return StatusCode(StatusCodes.Status500InternalServerError, new ApiResponse<dynamic>(BuscaMissa.Constants.Constants.MensagemErroInterno));
+            }
+        }
+
+        [HttpPost]
+        [Route("{controleId}/ajustar")]
+        public async Task<IActionResult> AjustarAlteracao(int controleId, [FromBody] AjustarAlteracaoRequest request)
+        {
+            try
+            {
+                if (!ModelState.IsValid) return BadRequest(ModelState);
+
+                var sucesso = await aprovacaoService.AjustarAlteracaoAsync(controleId, request);
+                if (!sucesso) return BadRequest(new ApiResponse<dynamic>(new { mensagemAplicacao = "Não foi possível concluir o ajuste." }));
+                return Ok(new ApiResponse<dynamic>(new { mensagemAplicacao = "Alteração ajustada e concluída com sucesso." }));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                return StatusCode(StatusCodes.Status500InternalServerError, new ApiResponse<dynamic>(BuscaMissa.Constants.Constants.MensagemErroInterno));
+            }
+        }
+
+        [HttpPost]
+        [Route("{controleId}/rejeitar")]
+        public async Task<IActionResult> Rejeitar(int controleId)
+        {
+            try
+            {
+                var sucesso = await aprovacaoService.RejeitarAsync(controleId);
+                if (!sucesso) return BadRequest(new ApiResponse<dynamic>(new { mensagemAplicacao = "Não foi possível rejeitar este item." }));
+                return Ok(new ApiResponse<dynamic>(new { mensagemAplicacao = "Rejeitado." }));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                return StatusCode(StatusCodes.Status500InternalServerError, new ApiResponse<dynamic>(BuscaMissa.Constants.Constants.MensagemErroInterno));
+            }
+        }
+    }
+}

--- a/BuscaMissa/DTOs/v1/ControleDto/AjustarAlteracaoRequest.cs
+++ b/BuscaMissa/DTOs/v1/ControleDto/AjustarAlteracaoRequest.cs
@@ -1,0 +1,14 @@
+using BuscaMissa.DTOs.MissaDto;
+using BuscaMissa.Filters;
+
+namespace BuscaMissa.DTOs.ControleDto
+{
+    // Dados ajustados pelo Admin antes de concluir uma alteração pendente
+    // (a igreja em si já existe — só Paroco/Imagem/Missas fazem parte desse fluxo).
+    public class AjustarAlteracaoRequest
+    {
+        [NoProfanity] public string? Paroco { get; set; }
+        public string? Imagem { get; set; }
+        public ICollection<MissaRequest> Missas { get; set; } = [];
+    }
+}

--- a/BuscaMissa/DTOs/v1/ControleDto/ControleDetalheResponse.cs
+++ b/BuscaMissa/DTOs/v1/ControleDto/ControleDetalheResponse.cs
@@ -1,0 +1,17 @@
+using BuscaMissa.Enums;
+
+namespace BuscaMissa.DTOs.ControleDto
+{
+    public class ControleDetalheResponse
+    {
+        public int ControleId { get; set; }
+        public StatusEnum Status { get; set; }
+        public DateTime DataCriacao { get; set; }
+        public string Tipo { get; set; } = default!;
+        public int? IgrejaId { get; set; }
+
+        // Nulo para criação (não há "antes" — a igreja ainda não existe publicamente).
+        public DadosComparacaoResponse? DadosAtuais { get; set; }
+        public DadosComparacaoResponse DadosPropostos { get; set; } = default!;
+    }
+}

--- a/BuscaMissa/DTOs/v1/ControleDto/ControlePendenteResponse.cs
+++ b/BuscaMissa/DTOs/v1/ControleDto/ControlePendenteResponse.cs
@@ -1,0 +1,20 @@
+using BuscaMissa.Enums;
+
+namespace BuscaMissa.DTOs.ControleDto
+{
+    // Item da fila de Aprovações Pendentes — lista o que já existe em Controle/Igreja,
+    // sem nenhuma tabela de log nova.
+    public class ControlePendenteResponse
+    {
+        public int ControleId { get; set; }
+        public StatusEnum Status { get; set; }
+        public DateTime DataCriacao { get; set; }
+        public int? IgrejaId { get; set; }
+        public string? NomeIgreja { get; set; }
+        public string? Cidade { get; set; }
+        public string? Uf { get; set; }
+
+        // "Criacao" ou "Alteracao" — derivado do Status.
+        public string Tipo { get; set; } = default!;
+    }
+}

--- a/BuscaMissa/DTOs/v1/ControleDto/DadosComparacaoResponse.cs
+++ b/BuscaMissa/DTOs/v1/ControleDto/DadosComparacaoResponse.cs
@@ -1,0 +1,22 @@
+using BuscaMissa.DTOs.EnderecoDto;
+
+namespace BuscaMissa.DTOs.ControleDto
+{
+    // Um lado do comparativo antes/depois (dados atuais da igreja OU dados propostos
+    // vindos de IgrejaTemporaria/MissaTemporaria — para criação, o "atual" fica nulo).
+    public class DadosComparacaoResponse
+    {
+        public string? Nome { get; set; }
+        public string? Paroco { get; set; }
+        public string? ImagemUrl { get; set; }
+        public EnderecoIgrejaResponse? Endereco { get; set; }
+        public IList<MissaComparacaoItem> Missas { get; set; } = [];
+    }
+
+    public class MissaComparacaoItem
+    {
+        public string DiaSemana { get; set; } = default!;
+        public string Horario { get; set; } = default!;
+        public string? Observacao { get; set; }
+    }
+}

--- a/BuscaMissa/DTOs/v1/ControleDto/FiltroControleRequest.cs
+++ b/BuscaMissa/DTOs/v1/ControleDto/FiltroControleRequest.cs
@@ -1,0 +1,12 @@
+using BuscaMissa.DTOs.PaginacaoDto;
+using BuscaMissa.Enums;
+
+namespace BuscaMissa.DTOs.ControleDto
+{
+    public class FiltroControleRequest
+    {
+        // Sem status informado, lista só os pendentes (nem Finalizado, nem Rejeitado).
+        public StatusEnum? Status { get; set; }
+        public PaginacaoRequest Paginacao { get; set; } = new();
+    }
+}

--- a/BuscaMissa/Enums/StatusEnum.cs
+++ b/BuscaMissa/Enums/StatusEnum.cs
@@ -3,6 +3,8 @@ namespace BuscaMissa.Enums
     public enum StatusEnum
     {
         Finalizado = 1,
+        // Admin recusou a criação/alteração pendente (fila de Aprovações) — distinto de Finalizado.
+        Rejeitado = 2,
         Igreja_Criacao = 100,
         Igreja_Criacao_Aguardando_Codigo_Validador = 101,
         Igreja_Atualizacao_Temporaria_Inserido = 200,

--- a/BuscaMissa/Migrations/20260708140613_controle_data_criacao_status_rejeitado.Designer.cs
+++ b/BuscaMissa/Migrations/20260708140613_controle_data_criacao_status_rejeitado.Designer.cs
@@ -4,6 +4,7 @@ using BuscaMissa.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BuscaMissa.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260708140613_controle_data_criacao_status_rejeitado")]
+    partial class controle_data_criacao_status_rejeitado
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BuscaMissa/Migrations/20260708140613_controle_data_criacao_status_rejeitado.cs
+++ b/BuscaMissa/Migrations/20260708140613_controle_data_criacao_status_rejeitado.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BuscaMissa.Migrations
+{
+    /// <inheritdoc />
+    public partial class controle_data_criacao_status_rejeitado : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DataCriacao",
+                table: "Controles",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataCriacao",
+                table: "Controles");
+        }
+    }
+}

--- a/BuscaMissa/Models/Controle.cs
+++ b/BuscaMissa/Models/Controle.cs
@@ -10,5 +10,6 @@ namespace BuscaMissa.Models
         public StatusEnum Status { get; set; }
         public int? IgrejaId { get; set; }
         public Igreja? Igreja { get; set; }
+        public DateTime DataCriacao { get; set; } = DateTime.Now;
     }
 }

--- a/BuscaMissa/Program.cs
+++ b/BuscaMissa/Program.cs
@@ -75,6 +75,7 @@ builder.Services.AddScoped<IgrejaService>();
 builder.Services.AddScoped<UsuarioService>();
 builder.Services.AddScoped<ImagemService>();
 builder.Services.AddScoped<IgrejaTemporariaService>();
+builder.Services.AddScoped<AprovacaoService>();
 builder.Services.AddScoped<ContatoService>();
 builder.Services.AddScoped<IgrejaReportarProblemaService>();
 builder.Services.AddScoped<SolicitacaoService>();

--- a/BuscaMissa/Services/v1/AprovacaoService.cs
+++ b/BuscaMissa/Services/v1/AprovacaoService.cs
@@ -1,0 +1,238 @@
+using BuscaMissa.Context;
+using BuscaMissa.DTOs.ControleDto;
+using BuscaMissa.DTOs.EnderecoDto;
+using BuscaMissa.DTOs.IgrejaDto;
+using BuscaMissa.DTOs.MissaDto;
+using BuscaMissa.DTOs.PaginacaoDto;
+using BuscaMissa.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace BuscaMissa.Services.v1;
+
+// Fila de "Aprovações Pendentes" do Admin — reaproveita Controle/IgrejaTemporaria/MissaTemporaria
+// que já existem para o fluxo público de criação/alteração validado por e-mail. Não cria
+// nenhuma tabela de log/histórico: só dá visibilidade e ações administrativas sobre o que
+// já está pendente, chamando os mesmos métodos de serviço que o fluxo por token já usa.
+public class AprovacaoService(
+    ApplicationDbContext context,
+    IgrejaService igrejaService,
+    IgrejaTemporariaService igrejaTemporariaService,
+    ILogger<AprovacaoService> logger)
+{
+    // Statuses que representam algo aguardando ação (nem concluído, nem rejeitado).
+    private static readonly StatusEnum[] StatusPendentes =
+    [
+        StatusEnum.Igreja_Criacao,
+        StatusEnum.Igreja_Criacao_Aguardando_Codigo_Validador,
+        StatusEnum.Igreja_Atualizacao_Temporaria_Inserido,
+        StatusEnum.Igreja_Atualizacao_Aguardando_Codigo_Validador,
+    ];
+
+    private static string ObterTipo(StatusEnum status) =>
+        status is StatusEnum.Igreja_Criacao or StatusEnum.Igreja_Criacao_Aguardando_Codigo_Validador
+            ? "Criacao"
+            : "Alteracao";
+
+    public async Task<Paginacao<ControlePendenteResponse>> BuscarPendentesAsync(FiltroControleRequest filtro)
+    {
+        try
+        {
+            var query = context.Controles
+                .Include(x => x.Igreja)
+                .ThenInclude(x => x!.Endereco)
+                .AsNoTracking()
+                .AsQueryable();
+
+            query = filtro.Status.HasValue
+                ? query.Where(x => x.Status == filtro.Status.Value)
+                : query.Where(x => StatusPendentes.Contains(x.Status));
+
+            var total = await query.CountAsync();
+
+            var itens = await query
+                .OrderBy(x => x.DataCriacao)
+                .Skip((filtro.Paginacao.PageIndex - 1) * filtro.Paginacao.PageSize)
+                .Take(filtro.Paginacao.PageSize)
+                .Select(x => new ControlePendenteResponse
+                {
+                    ControleId = x.Id,
+                    Status = x.Status,
+                    DataCriacao = x.DataCriacao,
+                    IgrejaId = x.IgrejaId,
+                    NomeIgreja = x.Igreja!.Nome,
+                    Cidade = x.Igreja.Endereco.Localidade,
+                    Uf = x.Igreja.Endereco.Uf,
+                    Tipo = ObterTipo(x.Status),
+                })
+                .ToListAsync();
+
+            return new Paginacao<ControlePendenteResponse>(
+                filtro.Paginacao.PageIndex, filtro.Paginacao.PageSize, total, itens);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Erro ao buscar fila de aprovações pendentes");
+            throw;
+        }
+    }
+
+    public async Task<ControleDetalheResponse?> ObterDetalheAsync(int controleId)
+    {
+        var controle = await context.Controles
+            .Include(x => x.Igreja)
+            .ThenInclude(x => x!.Endereco)
+            .Include(x => x.Igreja)
+            .ThenInclude(x => x!.Missas)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == controleId);
+
+        if (controle?.Igreja is null) return null;
+
+        var tipo = ObterTipo(controle.Status);
+        var response = new ControleDetalheResponse
+        {
+            ControleId = controle.Id,
+            Status = controle.Status,
+            DataCriacao = controle.DataCriacao,
+            Tipo = tipo,
+            IgrejaId = controle.IgrejaId,
+        };
+
+        if (tipo == "Criacao")
+        {
+            // Não há "antes" — a igreja proposta é a própria igreja (ainda inativa).
+            response.DadosAtuais = null;
+            response.DadosPropostos = new DadosComparacaoResponse
+            {
+                Nome = controle.Igreja.Nome,
+                Paroco = controle.Igreja.Paroco,
+                ImagemUrl = controle.Igreja.ImagemUrl,
+                Endereco = (EnderecoIgrejaResponse)controle.Igreja.Endereco,
+                Missas = controle.Igreja.Missas.Select(m => new MissaComparacaoItem
+                {
+                    DiaSemana = m.DiaSemana.ToString(),
+                    Horario = m.Horario.ToString(@"hh\:mm"),
+                    Observacao = m.Observacao,
+                }).ToList(),
+            };
+            return response;
+        }
+
+        // Alteração: "atual" é a igreja como está publicada hoje; "proposto" vem da
+        // IgrejaTemporaria/MissaTemporaria (dados enviados pelo usuário, aguardando validação).
+        response.DadosAtuais = new DadosComparacaoResponse
+        {
+            Nome = controle.Igreja.Nome,
+            Paroco = controle.Igreja.Paroco,
+            ImagemUrl = controle.Igreja.ImagemUrl,
+            Missas = controle.Igreja.Missas.Select(m => new MissaComparacaoItem
+            {
+                DiaSemana = m.DiaSemana.ToString(),
+                Horario = m.Horario.ToString(@"hh\:mm"),
+                Observacao = m.Observacao,
+            }).ToList(),
+        };
+
+        var temporaria = await context.IgrejaTemporarias
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.IgrejaId == controle.IgrejaId);
+
+        var missasTemp = await context.MissasTemporarias
+            .AsNoTracking()
+            .Where(x => x.IgrejaId == controle.IgrejaId)
+            .ToListAsync();
+
+        response.DadosPropostos = new DadosComparacaoResponse
+        {
+            Nome = controle.Igreja.Nome,
+            Paroco = temporaria?.Paroco,
+            ImagemUrl = temporaria?.ImagemUrl,
+            Missas = missasTemp.Select(m => new MissaComparacaoItem
+            {
+                DiaSemana = m.DiaSemana.ToString(),
+                Horario = m.Horario.ToString(@"hh\:mm"),
+                Observacao = m.Observacao,
+            }).ToList(),
+        };
+
+        return response;
+    }
+
+    /// <summary>Aprova como está — mesma finalização que o fluxo de token já faz, sem exigir um Usuario validado.</summary>
+    public async Task<bool> AprovarAsync(int controleId)
+    {
+        var controle = await context.Controles
+            .Include(x => x.Igreja)
+            .ThenInclude(x => x!.Missas)
+            .FirstOrDefaultAsync(x => x.Id == controleId);
+
+        if (controle?.Igreja is null) return false;
+
+        if (ObterTipo(controle.Status) == "Criacao")
+        {
+            controle.Igreja.Ativo = true;
+            controle.Igreja.Alteracao = DateTime.Now;
+        }
+        else
+        {
+            var temporaria = await igrejaTemporariaService.BuscarPorIgrejaIdAsync(controle.Igreja.Id);
+            if (temporaria is null) return false;
+
+            var aplicado = await igrejaService.EditarPorTemporariaAsync(controle.Igreja, temporaria);
+            if (!aplicado) return false;
+        }
+
+        controle.Status = StatusEnum.Finalizado;
+        await context.SaveChangesAsync();
+        return true;
+    }
+
+    /// <summary>Alteração: aplica os dados ajustados pelo Admin (em vez dos propostos originalmente) e finaliza.</summary>
+    public async Task<bool> AjustarAlteracaoAsync(int controleId, AjustarAlteracaoRequest request)
+    {
+        var controle = await context.Controles
+            .Include(x => x.Igreja)
+            .ThenInclude(x => x!.Missas)
+            .FirstOrDefaultAsync(x => x.Id == controleId);
+
+        if (controle?.Igreja is null || ObterTipo(controle.Status) != "Alteracao") return false;
+
+        var atualizacaoAjustada = new AtualizacaoIgrejaResponse
+        {
+            Id = controle.Igreja.Id,
+            Nome = controle.Igreja.Nome,
+            Paroco = request.Paroco,
+            ImagemUrl = request.Imagem,
+            MissasTemporaria = request.Missas.Select(m => new MissaResponse
+            {
+                DiaSemana = m.DiaSemana,
+                Horario = m.Horario,
+                Observacao = m.Observacao,
+            }).ToList(),
+        };
+
+        var aplicado = await igrejaService.EditarPorTemporariaAsync(controle.Igreja, atualizacaoAjustada);
+        if (!aplicado) return false;
+
+        controle.Status = StatusEnum.Finalizado;
+        await context.SaveChangesAsync();
+        return true;
+    }
+
+    /// <summary>Recusa a pendência. Para alteração, limpa os dados temporários; a igreja publicada não é tocada.</summary>
+    public async Task<bool> RejeitarAsync(int controleId)
+    {
+        var controle = await context.Controles.FirstOrDefaultAsync(x => x.Id == controleId);
+        if (controle is null) return false;
+
+        if (ObterTipo(controle.Status) == "Alteracao" && controle.IgrejaId.HasValue)
+        {
+            await igrejaTemporariaService.DeletaIgrejaAsync(controle.IgrejaId.Value);
+            await igrejaTemporariaService.DeletaMissasTemporarias(controle.IgrejaId.Value);
+        }
+
+        controle.Status = StatusEnum.Rejeitado;
+        await context.SaveChangesAsync();
+        return true;
+    }
+}


### PR DESCRIPTION
## Resumo
Dá visibilidade e controle administrativo sobre igrejas em criação/alteração que estão aguardando validação por e-mail (fluxo de `Controle` + `IgrejaTemporaria`/`MissaTemporaria`), sem criar nenhuma tabela de log/histórico — só expõe o que já existe com uma API adequada.

## Mudanças
- `Controle` ganha `DataCriacao` (não existia nenhum timestamp na tabela) e `StatusEnum` ganha `Rejeitado`, distinto de `Finalizado`.
- `AprovacaoService` novo:
  - `BuscarPendentesAsync` — lista paginada filtrando por status (sem filtro, mostra só os pendentes).
  - `ObterDetalheAsync` — comparativo antes/depois (nulo para criação, já que não existe "antes").
  - `AprovarAsync` — finaliza reaproveitando os mesmos métodos que o fluxo de token por e-mail já usa (`AtivarAsync`/`EditarPorTemporariaAsync`), sem exigir um Usuario validado.
  - `AjustarAlteracaoAsync` — Admin edita Paroco/Imagem/Missas antes de concluir uma alteração pendente.
  - `RejeitarAsync` — limpa os dados temporários sem tocar na igreja publicada.
- Novo `AprovacaoController` (`api/v1/Aprovacao`, `Authorize(Roles = "Admin")`).
- Migration aditiva (`AddColumn DataCriacao`, default para linhas existentes = `DateTime.MinValue`, já que não há como recuperar a data real de linhas antigas).

## Dependência
PR companheiro no frontend admin (tela "Aprovações Pendentes") ainda por vir.

## Test plan
- [x] `dotnet build` sem erros
- [x] Migration gerada e revisada (aditiva, sem downtime)
- [ ] Teste manual: aprovar/ajustar/rejeitar um item pendente de cada tipo (criação e alteração)