### PR TITLE
fix: DiaSemana como texto nas Aprovações + parâmetro ignorarCache em obter-enderecos

### DIFF
--- a/BuscaMissa/Controllers/v1/IgrejaController.cs
+++ b/BuscaMissa/Controllers/v1/IgrejaController.cs
@@ -277,11 +277,11 @@ namespace BuscaMissa.Controllers.v1
         [HttpGet]
         [Route("v2/obter-enderecos")]
         [Authorize(Roles = "App, Admin")]
-        public async Task<ActionResult> ObterDadosDeBuscaAsync()
-        {   
+        public async Task<ActionResult> ObterDadosDeBuscaAsync([FromQuery] bool ignorarCache = false)
+        {
             try
             {
-                var resultado = await enderecoService.OrganizarEnderecosAsync();
+                var resultado = await enderecoService.OrganizarEnderecosAsync(ignorarCache);
                 return Ok(new ApiResponse<dynamic>(resultado));
             }
             catch (Exception ex)

--- a/BuscaMissa/DTOs/v1/ControleDto/DadosComparacaoResponse.cs
+++ b/BuscaMissa/DTOs/v1/ControleDto/DadosComparacaoResponse.cs
@@ -1,4 +1,5 @@
 using BuscaMissa.DTOs.EnderecoDto;
+using BuscaMissa.Enums;
 
 namespace BuscaMissa.DTOs.ControleDto
 {
@@ -15,7 +16,8 @@ namespace BuscaMissa.DTOs.ControleDto
 
     public class MissaComparacaoItem
     {
-        public string DiaSemana { get; set; } = default!;
+        // Numérico (mesmo valor de DiaDaSemanaEnum) — o frontend já converte para label.
+        public DiaDaSemanaEnum DiaSemana { get; set; }
         public string Horario { get; set; } = default!;
         public string? Observacao { get; set; }
     }

--- a/BuscaMissa/Services/v1/AprovacaoService.cs
+++ b/BuscaMissa/Services/v1/AprovacaoService.cs
@@ -110,7 +110,7 @@ public class AprovacaoService(
                 Endereco = (EnderecoIgrejaResponse)controle.Igreja.Endereco,
                 Missas = controle.Igreja.Missas.Select(m => new MissaComparacaoItem
                 {
-                    DiaSemana = m.DiaSemana.ToString(),
+                    DiaSemana = m.DiaSemana,
                     Horario = m.Horario.ToString(@"hh\:mm"),
                     Observacao = m.Observacao,
                 }).ToList(),
@@ -127,7 +127,7 @@ public class AprovacaoService(
             ImagemUrl = controle.Igreja.ImagemUrl,
             Missas = controle.Igreja.Missas.Select(m => new MissaComparacaoItem
             {
-                DiaSemana = m.DiaSemana.ToString(),
+                DiaSemana = m.DiaSemana,
                 Horario = m.Horario.ToString(@"hh\:mm"),
                 Observacao = m.Observacao,
             }).ToList(),
@@ -149,7 +149,7 @@ public class AprovacaoService(
             ImagemUrl = temporaria?.ImagemUrl,
             Missas = missasTemp.Select(m => new MissaComparacaoItem
             {
-                DiaSemana = m.DiaSemana.ToString(),
+                DiaSemana = m.DiaSemana,
                 Horario = m.Horario.ToString(@"hh\:mm"),
                 Observacao = m.Observacao,
             }).ToList(),

--- a/BuscaMissa/Services/v1/EnderecoService.cs
+++ b/BuscaMissa/Services/v1/EnderecoService.cs
@@ -66,11 +66,15 @@ namespace BuscaMissa.Services.v1
             }
         }
 
-        public async Task<Dictionary<string, Dictionary<string, List<string>>>> OrganizarEnderecosAsync()
+        // ignorarCache: usado pelo Admin ao ajustar dados de igreja e precisar ver o
+        // resultado imediatamente, sem esperar o TTL de 10 minutos. O cache é
+        // recalculado e reescrito normalmente, só não é lido nessa chamada.
+        public async Task<Dictionary<string, Dictionary<string, List<string>>>> OrganizarEnderecosAsync(bool ignorarCache = false)
         {
             try
             {
-            if (_cache.TryGetValue(CacheKeyOrganizarEnderecos,
+            if (!ignorarCache &&
+                _cache.TryGetValue(CacheKeyOrganizarEnderecos,
                     out Dictionary<string, Dictionary<string, List<string>>>? cached) && cached is not null)
                 return cached;
 


### PR DESCRIPTION
## Resumo
Dois itens neste PR:

1. **Fix esquecido do PR #94**: `DadosComparacaoResponse.MissaComparacaoItem.DiaSemana` estava sendo serializado como string (nome do enum) em vez do valor numérico que o admin espera (`MissaForm` e o request de ajuste usam o valor de `DiaDaSemanaEnum`). Esse fix tinha sido feito localmente mas ficou fora do commit que foi mesclado — corrigido aqui.

2. **`GET /api/v1/Igreja/v2/obter-enderecos` ganha parâmetro opcional `ignorarCache`** (default `false`, sem mudança de comportamento pra quem já chama sem ele). O endpoint cacheia por 10 minutos sem invalidação ativa — isso atrasava a visibilidade de ajustes feitos no Admin (nova cidade/bairro só aparecia depois do TTL). Quando `ignorarCache=true`, pula a leitura do cache mas continua recalculando e reescrevendo, mantendo-o quente pras próximas chamadas normais do site público.

Companheiro do [PR do admin](https://github.com/FabioVeiga/buscamissa-frondend-admin/pull/81).

## Test plan
- [x] `dotnet build` sem erros
- [ ] Teste manual: editar cidade/bairro de uma igreja e confirmar que `?ignorarCache=true` retorna o dado atualizado imediatamente