### PR TITLE
feat: remove obrigatoriedade do Bairro no endereço da igreja

### DIFF
--- a/BuscaMissa/DTOs/v1/EnderecoDto/EnderecoIgrejaRequest.cs
+++ b/BuscaMissa/DTOs/v1/EnderecoDto/EnderecoIgrejaRequest.cs
@@ -10,8 +10,8 @@ namespace BuscaMissa.DTOs.EnderecoDto
         public string Logradouro { get; set; } = default!;
         [NoProfanity]
         public string? Complemento { get; set; }
-        [Required]
-        public string Bairro { get; set; } = default!;
+        // Opcional — nem todo endereço tem bairro (áreas rurais, cidades pequenas).
+        public string? Bairro { get; set; }
         [Required]
         public string Localidade { get; set; } = default!;
         [Required]

--- a/BuscaMissa/Migrations/20260708161334_endereco_bairro_opcional.Designer.cs
+++ b/BuscaMissa/Migrations/20260708161334_endereco_bairro_opcional.Designer.cs
@@ -4,6 +4,7 @@ using BuscaMissa.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BuscaMissa.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260708161334_endereco_bairro_opcional")]
+    partial class endereco_bairro_opcional
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BuscaMissa/Migrations/20260708161334_endereco_bairro_opcional.cs
+++ b/BuscaMissa/Migrations/20260708161334_endereco_bairro_opcional.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BuscaMissa.Migrations
+{
+    /// <inheritdoc />
+    public partial class endereco_bairro_opcional : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Bairro",
+                table: "Enderecos",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Enderecos",
+                keyColumn: "Bairro",
+                keyValue: null,
+                column: "Bairro",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Bairro",
+                table: "Enderecos",
+                type: "longtext",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/BuscaMissa/Models/Endereco.cs
+++ b/BuscaMissa/Models/Endereco.cs
@@ -14,8 +14,8 @@ namespace BuscaMissa.Models
         [Required]
         public string Logradouro { get; set; } = default!;
         public string? Complemento { get; set; }
-        [Required]
-        public string Bairro { get; set; } = default!;
+        // Opcional — nem todo endereço tem bairro (áreas rurais, cidades pequenas).
+        public string? Bairro { get; set; }
         [Required]
         public string Localidade { get; set; } = default!;
         // Slug da cidade para URLs e busca (ex: "sao-jose-dos-campos"). Persistido e indexado.


### PR DESCRIPTION
## Resumo
Removida a exigência de `Bairro` no cadastro/edição de endereço de igreja:

- `EnderecoIgrejaRequest.Bairro`: removido `[Required]`, campo agora `string?`.
- `Endereco.Bairro` (model): agora `string?`.
- Migration `endereco_bairro_opcional`: `ALTER COLUMN Bairro` para nullable no banco (aditiva, sem perda de dado — down migration faz backfill para string vazia antes de reverter, caso precise desfazer).

## Escopo — atenção
Não existe um DTO de endereço específico do Admin — `EnderecoIgrejaRequest` é compartilhado entre o cadastro/edição do Admin **e** o fluxo público de auto-cadastro de igreja (mesma classe usada nos dois). Essa mudança relaxa a exigência nos dois fluxos, não só no Admin.

Revisei todos os usos de `.Bairro` no código (buscas, geocodificação, slugs, SEO) — nenhum quebra com valor nulo, já tratam com `IsNullOrWhiteSpace`/`?? string.Empty` onde necessário.

## Test plan
- [x] `dotnet build` sem erros
- [x] Migration gerada e revisada (aditiva)
- [ ] Teste manual: cadastrar/editar igreja no Admin sem preencher Bairro