### PR TITLE
feat: expõe usuário responsável na fila de Aprovações Pendentes

### DIFF
--- a/BuscaMissa/DTOs/v1/ControleDto/ControleDetalheResponse.cs
+++ b/BuscaMissa/DTOs/v1/ControleDto/ControleDetalheResponse.cs
@@ -9,6 +9,8 @@ namespace BuscaMissa.DTOs.ControleDto
         public DateTime DataCriacao { get; set; }
         public string Tipo { get; set; } = default!;
         public int? IgrejaId { get; set; }
+        public string? UsuarioNome { get; set; }
+        public string? UsuarioEmail { get; set; }
 
         // Nulo para criação (não há "antes" — a igreja ainda não existe publicamente).
         public DadosComparacaoResponse? DadosAtuais { get; set; }

--- a/BuscaMissa/DTOs/v1/ControleDto/ControlePendenteResponse.cs
+++ b/BuscaMissa/DTOs/v1/ControleDto/ControlePendenteResponse.cs
@@ -14,6 +14,11 @@ namespace BuscaMissa.DTOs.ControleDto
         public string? Cidade { get; set; }
         public string? Uf { get; set; }
 
+        // Nulo em criações ainda não aprovadas — o contribuidor só é vinculado à
+        // igreja quando o Admin aprova (ver AprovacaoService.AprovarAsync).
+        public string? UsuarioNome { get; set; }
+        public string? UsuarioEmail { get; set; }
+
         // "Criacao" ou "Alteracao" — derivado do Status.
         public string Tipo { get; set; } = default!;
     }

--- a/BuscaMissa/Services/v1/AprovacaoService.cs
+++ b/BuscaMissa/Services/v1/AprovacaoService.cs
@@ -40,6 +40,8 @@ public class AprovacaoService(
             var query = context.Controles
                 .Include(x => x.Igreja)
                 .ThenInclude(x => x!.Endereco)
+                .Include(x => x.Igreja)
+                .ThenInclude(x => x!.Usuario)
                 .AsNoTracking()
                 .AsQueryable();
 
@@ -63,6 +65,8 @@ public class AprovacaoService(
                     Cidade = x.Igreja.Endereco.Localidade,
                     Uf = x.Igreja.Endereco.Uf,
                     Tipo = ObterTipo(x.Status),
+                    UsuarioNome = x.Igreja.Usuario != null ? x.Igreja.Usuario.Nome : null,
+                    UsuarioEmail = x.Igreja.Usuario != null ? x.Igreja.Usuario.Email : null,
                 })
                 .ToListAsync();
 
@@ -83,6 +87,8 @@ public class AprovacaoService(
             .ThenInclude(x => x!.Endereco)
             .Include(x => x.Igreja)
             .ThenInclude(x => x!.Missas)
+            .Include(x => x.Igreja)
+            .ThenInclude(x => x!.Usuario)
             .AsNoTracking()
             .FirstOrDefaultAsync(x => x.Id == controleId);
 
@@ -96,6 +102,8 @@ public class AprovacaoService(
             DataCriacao = controle.DataCriacao,
             Tipo = tipo,
             IgrejaId = controle.IgrejaId,
+            UsuarioNome = controle.Igreja.Usuario?.Nome,
+            UsuarioEmail = controle.Igreja.Usuario?.Email,
         };
 
         if (tipo == "Criacao")


### PR DESCRIPTION
## Resumo
`ControlePendenteResponse` e `ControleDetalheResponse` (endpoints `/api/v1/Aprovacao/*`) agora trazem `UsuarioNome`/`UsuarioEmail`, a partir de `Igreja.Usuario`.

**Limitação esperada**: para itens de **criação** ainda pendentes, o campo vem nulo — o vínculo `Igreja.UsuarioId` só é preenchido quando o Admin efetivamente aprova (`AprovacaoService.AprovarAsync`), então não há usuário para mostrar antes disso. Para **alteração**, geralmente já vem preenchido (igreja já publicada, ativada anteriormente).

## Test plan
- [x] `dotnet build` sem erros