### PR TITLE
feat: consolida envio de e-mail quando o mesmo contato administra várias igrejas

### DIFF
--- a/BuscaMissa/DTOs/v1/EmailHtmlGenerator/EmailHtmlGenerator.cs
+++ b/BuscaMissa/DTOs/v1/EmailHtmlGenerator/EmailHtmlGenerator.cs
@@ -74,6 +74,51 @@ namespace BuscaMissa.DTOs.v1.EmailHtmlGenerator
             return htmlBuilder.ToString();
         }
 
+        // Mesmo e-mail de contato cadastrado em várias igrejas (ex: diocese, secretaria
+        // paroquial) — um único e-mail com a lista de igrejas, em vez de um por igreja.
+        public static string GerarHtmlEmailMultiplasIgrejas(
+            IList<(string NomeIgreja, string LinkPaginaIgreja)> igrejas, bool criacao)
+        {
+            var introducao = criacao
+                ? "As igrejas abaixo foram cadastradas no Busca Missa, plataforma gratuita que ajuda os fiéis a encontrarem igrejas e horários de missas."
+                : "As informações das igrejas abaixo foram atualizadas no Busca Missa.";
+
+            var chamada = criacao
+                ? "Pedimos apenas um minuto da sua atenção para verificar se as informações de cada uma estão corretas:"
+                : "Para garantir que os fiéis encontrem sempre os horários corretos, pedimos que confira os dados de cada uma:";
+
+            var itensHtml = new StringBuilder();
+            foreach (var igreja in igrejas)
+            {
+                itensHtml.Append($@"
+                                <div class=""church-details"">
+                                    <p><strong>{igreja.NomeIgreja}</strong></p>
+                                    <div class=""button-container"" style=""margin: 10px 0;"">
+                                        <a href=""{igreja.LinkPaginaIgreja}"" class=""button"">👉 {(criacao ? "Conferir informações" : "Revisar informações")}</a>
+                                    </div>
+                                </div>");
+            }
+
+            var htmlBuilder = new StringBuilder();
+            htmlBuilder.Append(GetHtmlHeader());
+            htmlBuilder.Append($@"
+                    <tr>
+                        <td class=""content"">
+                            <h2>Olá!</h2>
+                            <p>{introducao}</p>
+                            <p>{chamada}</p>
+                            {itensHtml}
+                            <p>Caso seja necessário, você poderá solicitar qualquer alteração de forma simples e gratuita.</p>
+                            <p>Muito obrigado por nos ajudar a manter os dados sempre atualizados!</p>
+                            <p>Deus abençoe.</p>
+                            <p>Equipe Busca Missa</p>
+                        </td>
+                    </tr>");
+            htmlBuilder.Append(GetHtmlFooter());
+
+            return htmlBuilder.ToString();
+        }
+
         // Método auxiliar para formatar o endereço
         private static string FormatarEndereco(string logradouro, int? numero, string bairro, string localidade, string estado)
         {

--- a/BuscaMissa/Services/v1/DivulgacaoService.cs
+++ b/BuscaMissa/Services/v1/DivulgacaoService.cs
@@ -127,6 +127,16 @@ public class DivulgacaoService(
         };
     }
 
+    private string ConstruirLinkPagina(Igreja igreja) => string.Concat(
+        FrontendBaseUrl,
+        "/paroquia/",
+        igreja.Endereco.Uf.ToLower(),
+        "/",
+        igreja.Endereco.CidadeSlug,
+        "/",
+        igreja.Slug
+    );
+
     public async Task<bool> EnviarEmailAsync(Igreja igreja, bool criacao)
     {
         var emailContato = igreja.Contato?.EmailContato;
@@ -141,15 +151,7 @@ public class DivulgacaoService(
             if (string.IsNullOrWhiteSpace(emailContato))
                 return false;
 
-            var url = string.Concat(
-                FrontendBaseUrl,
-                "/paroquia/",
-                igreja.Endereco.Uf.ToLower(),
-                "/",
-                igreja.Endereco.CidadeSlug,
-                "/",
-                igreja.Slug
-            );
+            var url = ConstruirLinkPagina(igreja);
 
             if (criacao)
             {
@@ -259,6 +261,68 @@ public class DivulgacaoService(
         }
     }
 
+    /// <summary>
+    /// Mesmo e-mail de contato em várias igrejas (diocese, secretaria paroquial etc.) —
+    /// envia um único e-mail com a lista de todas, mas registra um EmailEventoIgreja por
+    /// igreja (mesma DataEnvio), pra não quebrar os filtros/contadores que são por igreja.
+    /// </summary>
+    private async Task<bool> EnviarEmailMultiploAsync(IList<Igreja> igrejas, bool criacao)
+    {
+        var emailContato = igrejas[0].Contato?.EmailContato;
+        var tipoEvento = criacao ? TipoEmailEventoIgrejaEnum.Criacao : TipoEmailEventoIgrejaEnum.Alteracao;
+        var nomesGrupo = string.Join(", ", igrejas.Select(x => x.Nome));
+
+        var assunto = criacao
+            ? $"#Busca Missa - Cadastro de {igrejas.Count} igrejas"
+            : $"#Busca Missa - Atualização das informações de {igrejas.Count} igrejas";
+
+        var itens = igrejas
+            .Select(igreja => (igreja.Nome, ConstruirLinkPagina(igreja)))
+            .ToList();
+
+        var html = EmailHtmlGenerator.GerarHtmlEmailMultiplasIgrejas(itens, criacao);
+
+        bool enviado;
+        try
+        {
+            var responseEmail = await emailService.EnviarEmail([emailContato!], assunto, html);
+            enviado = !string.IsNullOrWhiteSpace(responseEmail);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Erro ao enviar e-mail consolidado para {Email} ({Total} igrejas)", emailContato, igrejas.Count);
+            enviado = false;
+        }
+
+        foreach (var igreja in igrejas)
+        {
+            try
+            {
+                await emailEventoIgrejaService.InserirAsync(new CriarEmailEventoIgrejaRequest
+                {
+                    IgrejaId = igreja.Id,
+                    Tipo = tipoEvento,
+                    Assunto = assunto,
+                    EmailDestino = emailContato,
+                    NomeDestino = igreja.Nome,
+                    Html = html,
+                    Ativo = true,
+                    Enviado = enviado,
+                    DataEnvio = enviado ? DateTime.UtcNow : null,
+                    Observacao = enviado
+                        ? $"E-mail consolidado enviado junto com: {nomesGrupo}."
+                        : "Tentativa de envio de e-mail consolidado realizada, porém o serviço de e-mail não retornou confirmação."
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Erro ao registrar evento de e-mail consolidado. IgrejaId: {IgrejaId}", igreja.Id);
+            }
+        }
+
+        return enviado;
+    }
+
     public async Task<EnviarEmailLoteResponse> EnviarEmailLoteAsync(EnviarEmailLoteRequest request)
     {
         var criacao = request.Tipo.Contains("criacao", StringComparison.OrdinalIgnoreCase);
@@ -274,32 +338,45 @@ public class DivulgacaoService(
             TotalSolicitado = request.IgrejaIds.Count
         };
 
-        foreach (var igreja in igrejas)
+        var semEmail = igrejas.Where(x => string.IsNullOrWhiteSpace(x.Contato?.EmailContato)).ToList();
+        foreach (var igreja in semEmail)
         {
-            if (string.IsNullOrWhiteSpace(igreja.Contato?.EmailContato))
+            response.Falhas.Add(new EnvioLoteFalhaResponse
             {
-                response.Falhas.Add(new EnvioLoteFalhaResponse
-                {
-                    IgrejaId = igreja.Id,
-                    Nome = igreja.Nome,
-                    Motivo = "Igreja não possui e-mail de contato cadastrado."
-                });
-                continue;
-            }
+                IgrejaId = igreja.Id,
+                Nome = igreja.Nome,
+                Motivo = "Igreja não possui e-mail de contato cadastrado."
+            });
+        }
 
-            var enviado = await EnviarEmailAsync(igreja, criacao);
+        // Mesmo e-mail cadastrado em várias igrejas do lote → um único e-mail consolidado
+        // em vez de um por igreja (evita spam pro mesmo contato, ex: diocese/secretaria).
+        var grupos = igrejas
+            .Where(x => !string.IsNullOrWhiteSpace(x.Contato?.EmailContato))
+            .GroupBy(x => x.Contato!.EmailContato!.Trim().ToLowerInvariant());
+
+        foreach (var grupo in grupos)
+        {
+            var igrejasDoGrupo = grupo.ToList();
+            var enviado = igrejasDoGrupo.Count > 1
+                ? await EnviarEmailMultiploAsync(igrejasDoGrupo, criacao)
+                : await EnviarEmailAsync(igrejasDoGrupo[0], criacao);
+
             if (enviado)
             {
-                response.TotalEnviado++;
+                response.TotalEnviado += igrejasDoGrupo.Count;
             }
             else
             {
-                response.Falhas.Add(new EnvioLoteFalhaResponse
+                foreach (var igreja in igrejasDoGrupo)
                 {
-                    IgrejaId = igreja.Id,
-                    Nome = igreja.Nome,
-                    Motivo = "Falha ao enviar e-mail. Veja os logs para mais detalhes."
-                });
+                    response.Falhas.Add(new EnvioLoteFalhaResponse
+                    {
+                        IgrejaId = igreja.Id,
+                        Nome = igreja.Nome,
+                        Motivo = "Falha ao enviar e-mail. Veja os logs para mais detalhes."
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
## Resumo
No envio em lote da tela de Divulgação, cada igreja selecionada disparava um e-mail individual. Se o mesmo e-mail de contato estiver cadastrado em várias igrejas (diocese, secretaria paroquial etc.), a mesma pessoa recebia vários e-mails quase idênticos no mesmo lote.

## Mudanças
- `DivulgacaoService.EnviarEmailLoteAsync` agrupa as igrejas do lote por `Contato.EmailContato` (normalizado: trim + lowercase).
- Grupo com 1 igreja: comportamento igual ao atual (e-mail individual).
- Grupo com 2+ igrejas: `EnviarEmailMultiploAsync` envia **um único e-mail** consolidado, listando nome + link de cada igreja, usando o novo template `EmailHtmlGenerator.GerarHtmlEmailMultiplasIgrejas`.
- Rastreamento continua **por igreja**: mesmo com 1 e-mail físico enviado para 5 igrejas, ainda registro 5 linhas em `EmailEventosIgreja` (mesma `DataEnvio`), preservando os filtros existentes ("Sem contato via e-mail", "último contato enviado"), que são todos por igreja. A observação de cada evento indica que fez parte de um envio agrupado.
- Contrato de `EnviarEmailLoteResponse` inalterado — `TotalEnviado`/`Falhas` continuam contando por igreja.
- Nenhuma mudança necessária no frontend admin.

## Test plan
- [x] `dotnet build` sem erros
- [ ] Teste manual: selecionar 2+ igrejas com o mesmo e-mail de contato cadastrado e confirmar que chega só 1 e-mail, mas as duas ficam marcadas como contatadas