### PR TITLE
feat: ordenação configurável na listagem de usuários

### DIFF
--- a/BuscaMissa/DTOs/v1/UsuarioDto/UsuarioFiltroRequest.cs
+++ b/BuscaMissa/DTOs/v1/UsuarioDto/UsuarioFiltroRequest.cs
@@ -11,6 +11,12 @@ namespace BuscaMissa.DTOs.UsuarioDto
         public PerfilEnum? Perfil { get; set; }
         public DateTime? CriacaoInicio { get; set; }
         public DateTime? CriacaoFim { get; set; }
+
+        // Campo de ordenação: Nome, Email ou Criacao (default: Nome). Sem isso, Skip/Take
+        // sem ORDER BY é não-determinístico — cada página podia repetir/pular linhas.
+        public string? OrdenarPor { get; set; }
+        public bool OrdemDecrescente { get; set; } = false;
+
         public PaginacaoRequest Paginacao { get; set; } = default!;
     }
 }

--- a/BuscaMissa/Services/v1/UsuarioService.cs
+++ b/BuscaMissa/Services/v1/UsuarioService.cs
@@ -159,6 +159,13 @@ namespace BuscaMissa.Services.v1
             if(filtro.CriacaoFim.HasValue)
                 query = query.Where(x => x.Criacao <= filtro.CriacaoFim.Value);
 
+            query = filtro.OrdenarPor?.Trim().ToLowerInvariant() switch
+            {
+                "email" => filtro.OrdemDecrescente ? query.OrderByDescending(x => x.Email) : query.OrderBy(x => x.Email),
+                "criacao" => filtro.OrdemDecrescente ? query.OrderByDescending(x => x.Criacao) : query.OrderBy(x => x.Criacao),
+                _ => filtro.OrdemDecrescente ? query.OrderByDescending(x => x.Nome) : query.OrderBy(x => x.Nome),
+            };
+
             var resultado = await query.PaginacaoAsync(filtro.Paginacao.PageIndex, filtro.Paginacao.PageSize);
             return resultado;
         }


### PR DESCRIPTION
## Resumo
`GET .../usuario/buscar-por-filtro` (ou rota equivalente) agora aceita `OrdenarPor` (`Nome`/`Email`/`Criacao`, default `Nome`) e `OrdemDecrescente` (bool).

## Achado
A query de listagem de usuários rodava `Skip`/`Take` **sem nenhum `ORDER BY`** — isso é não-determinístico em SQL: a paginação podia repetir ou pular linhas entre páginas dependendo do plano de execução do banco. Corrigido como efeito colateral dessa mudança (agora sempre ordena por algo, default `Nome`).

## Test plan
- [x] `dotnet build` sem erros