### PR TITLE
feat: endpoint de listagem de Problemas Reportados

### DIFF
--- a/BuscaMissa/Controllers/v1/AdminController.cs
+++ b/BuscaMissa/Controllers/v1/AdminController.cs
@@ -495,6 +495,24 @@ namespace BuscaMissa.Controllers.v1
 
 
         [HttpGet]
+        [Route("igreja/reportar-problema")]
+        [Authorize(Roles = "Admin")]
+        public async Task<ActionResult> BuscarProblemasReportados([FromQuery] FiltroReportarProblemaRequest filtro)
+        {
+            try
+            {
+                var resultado = await igrejaReportarProblemaService.BuscarPorFiltroAsync(filtro);
+                return Ok(new ApiResponse<dynamic>(resultado));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Ex}", ex);
+                var response = new ApiResponse<dynamic>(BuscaMissa.Constants.Constants.MensagemErroInterno);
+                return StatusCode(StatusCodes.Status500InternalServerError, response);
+            }
+        }
+
+        [HttpGet]
         [Route("igreja/buscar-por-filtro")]
         [Authorize(Roles = "Admin")]
         public async Task<ActionResult> BuscarPorFiltro([FromQuery] FiltroIgrejaAdminRequest filtro)

--- a/BuscaMissa/DTOs/v1/IgrejaDto/FiltroReportarProblemaRequest.cs
+++ b/BuscaMissa/DTOs/v1/IgrejaDto/FiltroReportarProblemaRequest.cs
@@ -1,0 +1,12 @@
+using BuscaMissa.DTOs.PaginacaoDto;
+
+namespace BuscaMissa.DTOs.IgrejaDto
+{
+    public class FiltroReportarProblemaRequest
+    {
+        // Sem informar, lista só os pendentes (AcaoRealizada vazio) — mesmo padrão
+        // já usado no filtro de Igrejas (FiltroIgrejaAdminRequest.ReportarProblema).
+        public bool? Resolvido { get; set; }
+        public PaginacaoRequest Paginacao { get; set; } = new();
+    }
+}

--- a/BuscaMissa/DTOs/v1/IgrejaDto/ReportarProblemaListItemResponse.cs
+++ b/BuscaMissa/DTOs/v1/IgrejaDto/ReportarProblemaListItemResponse.cs
@@ -1,0 +1,18 @@
+namespace BuscaMissa.DTOs.IgrejaDto
+{
+    // Item da listagem de "Problemas Reportados" no Admin — traz o suficiente da
+    // igreja pra exibir e linkar direto pra edição, sem precisar de outra chamada.
+    public class ReportarProblemaListItemResponse
+    {
+        public int Id { get; set; }
+        public string Descricao { get; set; } = default!;
+        public string? AcaoRealizada { get; set; }
+        public string Nome { get; set; } = default!;
+        public string Email { get; set; } = default!;
+        public DateTime DataCriacao { get; set; }
+        public int IgrejaId { get; set; }
+        public string NomeIgreja { get; set; } = default!;
+        public string? Cidade { get; set; }
+        public string? Uf { get; set; }
+    }
+}

--- a/BuscaMissa/Migrations/20260710164722_igreja_reportar_problema_data_criacao.Designer.cs
+++ b/BuscaMissa/Migrations/20260710164722_igreja_reportar_problema_data_criacao.Designer.cs
@@ -4,6 +4,7 @@ using BuscaMissa.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BuscaMissa.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710164722_igreja_reportar_problema_data_criacao")]
+    partial class igreja_reportar_problema_data_criacao
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BuscaMissa/Migrations/20260710164722_igreja_reportar_problema_data_criacao.cs
+++ b/BuscaMissa/Migrations/20260710164722_igreja_reportar_problema_data_criacao.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BuscaMissa.Migrations
+{
+    /// <inheritdoc />
+    public partial class igreja_reportar_problema_data_criacao : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DataCriacao",
+                table: "IgrejaReportarProblemas",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataCriacao",
+                table: "IgrejaReportarProblemas");
+        }
+    }
+}

--- a/BuscaMissa/Models/IgrejaReportarProblema.cs
+++ b/BuscaMissa/Models/IgrejaReportarProblema.cs
@@ -16,6 +16,7 @@ namespace BuscaMissa.Models
         public string Email { get; set; } = default!;
         public int IgrejaId { get; set; }
         public Igreja Igreja { get; set; } = null!;
+        public DateTime DataCriacao { get; set; } = DateTime.Now;
 
         public static explicit operator  IgrejaReportarProblema(ReportarProblemaRequest request){
             return new IgrejaReportarProblema{

--- a/BuscaMissa/Services/v1/IgrejaReportarProblemaService.cs
+++ b/BuscaMissa/Services/v1/IgrejaReportarProblemaService.cs
@@ -1,6 +1,8 @@
 using BuscaMissa.Context;
 using BuscaMissa.DTOs.IgrejaDto;
 using BuscaMissa.DTOs.MissaDto;
+using BuscaMissa.DTOs.PaginacaoDto;
+using BuscaMissa.Helpers;
 using BuscaMissa.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -58,6 +60,48 @@ namespace BuscaMissa.Services.v1
             }
         }
         
+
+        public async Task<Paginacao<ReportarProblemaListItemResponse>> BuscarPorFiltroAsync(FiltroReportarProblemaRequest filtro)
+        {
+            try
+            {
+                var query = _context.IgrejaReportarProblemas
+                    .Include(x => x.Igreja)
+                    .ThenInclude(x => x.Endereco)
+                    .AsNoTracking()
+                    .AsQueryable();
+
+                query = filtro.Resolvido switch
+                {
+                    true => query.Where(x => x.AcaoRealizada != null && x.AcaoRealizada != ""),
+                    false => query.Where(x => x.AcaoRealizada == null || x.AcaoRealizada == ""),
+                    null => query,
+                };
+
+                var aux = query
+                    .OrderByDescending(x => x.DataCriacao)
+                    .Select(x => new ReportarProblemaListItemResponse
+                    {
+                        Id = x.Id,
+                        Descricao = x.Descricao,
+                        AcaoRealizada = x.AcaoRealizada,
+                        Nome = x.Nome,
+                        Email = x.Email,
+                        DataCriacao = x.DataCriacao,
+                        IgrejaId = x.IgrejaId,
+                        NomeIgreja = x.Igreja.Nome,
+                        Cidade = x.Igreja.Endereco.Localidade,
+                        Uf = x.Igreja.Endereco.Uf,
+                    });
+
+                return await aux.PaginacaoAsync(filtro.Paginacao.PageIndex, filtro.Paginacao.PageSize);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao buscar problemas reportados por filtro");
+                throw;
+            }
+        }
 
         public async Task<bool> InserirAsync(ReportarProblemaRequest request)
         {


### PR DESCRIPTION
## Resumo
Até agora, "Problema Reportado" (`IgrejaReportarProblema`) só existia inline na tela de edição de cada igreja individualmente — não havia como ver todos os problemas reportados de todas as igrejas num só lugar (equivalente à tela de "Solicitações", mas para esse fluxo específico, que já é vinculado a uma igreja).

## Mudanças
- `IgrejaReportarProblema` ganha `DataCriacao` (não existia nenhum timestamp) — migration aditiva.
- Novo `GET /api/v1/admin/igreja/reportar-problema` — paginado, filtro opcional `Resolvido` (bool), já retorna nome/cidade/UF da igreja pra exibir direto na listagem sem chamada extra.

Companheiro do PR do frontend admin (nova tela "Problemas Reportados", com link/modal pra igreja).

## Test plan
- [x] `dotnet build` sem erros
- [x] Migration gerada e revisada (aditiva)